### PR TITLE
Update from obsolete endpoint

### DIFF
--- a/lib/installer.js
+++ b/lib/installer.js
@@ -26,7 +26,6 @@ const fs_1 = require("fs");
 const os = __importStar(require("os"));
 const path = __importStar(require("path"));
 const semver = __importStar(require("semver"));
-const util = __importStar(require("util"));
 const IS_WINDOWS = process.platform === 'win32';
 if (!tempDirectory) {
     let baseLocation;
@@ -175,39 +174,29 @@ class DotnetCoreInstaller {
     getDownloadUrls(osSuffixes, version) {
         return __awaiter(this, void 0, void 0, function* () {
             let downloadUrls = [];
-            let releasesJSON = yield this.getReleasesJson();
-            core.debug('Releases: ' + releasesJSON);
-            let releasesInfo = JSON.parse(yield releasesJSON.readBody());
+            var httpCallbackClient = new httpClient.HttpClient('setup-dotnet', [], {});
+            const releasesJsonUrl = yield this.getReleasesJsonUrl(httpCallbackClient, version.split('.'));
+            let releasesJSON = yield httpCallbackClient.get(releasesJsonUrl);
+            let releasesInfo = JSON.parse(yield releasesJSON.readBody())['releases'];
             releasesInfo = releasesInfo.filter((releaseInfo) => {
-                return (releaseInfo['version-sdk'] === version ||
-                    releaseInfo['version-sdk-display'] === version);
+                return (releaseInfo['sdk']['version'] === version ||
+                    releaseInfo['sdk']['version-display'] === version);
             });
             if (releasesInfo.length != 0) {
                 let release = releasesInfo[0];
-                let blobUrl = release['blob-sdk'];
-                let dlcUrl = release['dlc--sdk'];
-                let fileName = release['sdk-' + osSuffixes[0]]
-                    ? release['sdk-' + osSuffixes[0]]
-                    : release['sdk-' + osSuffixes[1]];
-                if (!!fileName) {
-                    fileName = fileName.trim();
-                    // For some latest version, the filename itself can be full download url.
-                    // Do a very basic check for url(instead of regex) as the url is only for downloading and
-                    // is coming from .net core releases json and not some ransom user input
-                    if (fileName.toLowerCase().startsWith('https://')) {
-                        downloadUrls.push(fileName);
+                let files = release['sdk']['files'];
+                files = files.filter((file) => {
+                    if (file['rid'] == osSuffixes[0] || file['rid'] == osSuffixes[1]) {
+                        return (file['url'].endsWith('.zip') || file['url'].endsWith('.tar.gz'));
                     }
-                    else {
-                        if (!!blobUrl) {
-                            downloadUrls.push(util.format('%s%s', blobUrl.trim(), fileName));
-                        }
-                        if (!!dlcUrl) {
-                            downloadUrls.push(util.format('%s%s', dlcUrl.trim(), fileName));
-                        }
-                    }
+                });
+                if (files.length > 0) {
+                    files.forEach((file) => {
+                        downloadUrls.push(file['url']);
+                    });
                 }
                 else {
-                    throw `The specified version's download links are not correctly formed in the supported versions document => ${DotNetCoreReleasesUrl}`;
+                    throw `The specified version's download links are not correctly formed in the supported versions document => ${releasesJsonUrl}`;
                 }
             }
             else {
@@ -221,9 +210,23 @@ class DotnetCoreInstaller {
             return downloadUrls;
         });
     }
-    getReleasesJson() {
-        var httpCallbackClient = new httpClient.HttpClient('setup-dotnet', [], {});
-        return httpCallbackClient.get(DotNetCoreReleasesUrl);
+    getReleasesJsonUrl(httpCallbackClient, versionParts) {
+        return __awaiter(this, void 0, void 0, function* () {
+            // First, get the location of the correct releases.json then get that.
+            const releasesIndex = yield httpCallbackClient.get(DotNetCoreIndexUrl);
+            let releasesInfo = JSON.parse(yield releasesIndex.readBody())['releases-index'];
+            releasesInfo = releasesInfo.filter((releaseInfo) => {
+                const sdkParts = releaseInfo['channel-version'].split('.');
+                if (versionParts.length >= 2 && versionParts[1] != 'x') {
+                    return versionParts[0] == sdkParts[0] && versionParts[1] == sdkParts[1];
+                }
+                return versionParts[0] == sdkParts[0];
+            });
+            if (releasesInfo.length === 0) {
+                throw `Could not find info for this version at ${DotNetCoreIndexUrl}`;
+            }
+            return releasesInfo[0]['releases.json'];
+        });
     }
     getFallbackDownloadUrls(version) {
         return __awaiter(this, void 0, void 0, function* () {
@@ -306,4 +309,4 @@ class DotnetCoreInstaller {
     }
 }
 exports.DotnetCoreInstaller = DotnetCoreInstaller;
-const DotNetCoreReleasesUrl = 'https://raw.githubusercontent.com/dotnet/core/master/release-notes/releases.json';
+const DotNetCoreIndexUrl = 'https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/releases-index.json';

--- a/lib/installer.js
+++ b/lib/installer.js
@@ -174,7 +174,7 @@ class DotnetCoreInstaller {
     getDownloadUrls(osSuffixes, version) {
         return __awaiter(this, void 0, void 0, function* () {
             let downloadUrls = [];
-            var httpCallbackClient = new httpClient.HttpClient('setup-dotnet', [], {});
+            const httpCallbackClient = new httpClient.HttpClient('actions/setup-dotnet', [], {});
             const releasesJsonUrl = yield this.getReleasesJsonUrl(httpCallbackClient, version.split('.'));
             let releasesJSON = yield httpCallbackClient.get(releasesJsonUrl);
             let releasesInfo = JSON.parse(yield releasesJSON.readBody())['releases'];
@@ -212,18 +212,18 @@ class DotnetCoreInstaller {
     }
     getReleasesJsonUrl(httpCallbackClient, versionParts) {
         return __awaiter(this, void 0, void 0, function* () {
-            // First, get the location of the correct releases.json then get that.
             const releasesIndex = yield httpCallbackClient.get(DotNetCoreIndexUrl);
             let releasesInfo = JSON.parse(yield releasesIndex.readBody())['releases-index'];
-            releasesInfo = releasesInfo.filter((releaseInfo) => {
-                const sdkParts = releaseInfo['channel-version'].split('.');
+            releasesInfo = releasesInfo.filter((info) => {
+                // channel-version is the first 2 elements of the version (e.g. 2.1), filter out versions that don't match 2.1.x.
+                const sdkParts = info['channel-version'].split('.');
                 if (versionParts.length >= 2 && versionParts[1] != 'x') {
                     return versionParts[0] == sdkParts[0] && versionParts[1] == sdkParts[1];
                 }
                 return versionParts[0] == sdkParts[0];
             });
             if (releasesInfo.length === 0) {
-                throw `Could not find info for this version at ${DotNetCoreIndexUrl}`;
+                throw `Could not find info for version ${versionParts.join('.')} at ${DotNetCoreIndexUrl}`;
             }
             return releasesInfo[0]['releases.json'];
         });


### PR DESCRIPTION
Dotnet deprecated the current endpoint we're using and is planning on removing it next week. This updates to the new endpoint.

Fixes #24 