### PR TITLE
GitHub Workflow to maintain tags

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,0 +1,34 @@
+name: Tag
+on:
+  push:
+    tags:
+      - '*'  
+jobs:
+  build:
+    runs-on: windows-latest
+    env:
+      GIT_REDIRECT_STDERR: 2>&1
+    steps:
+    - name: Get Tag name
+      run: |
+        $TAG_NAME = ($env:GITHUB_REF).Substring("refs/tags/".Length)
+        echo "::set-env name=TAG_NAME::$TAG_NAME"
+        $DOT_COUNT = ($TAG_NAME.ToCharArray() | Where-Object {$_ -eq '.'} | Measure-Object).Count
+        echo "::set-env name=DOT_COUNT::$DOT_COUNT"
+    - name: Checkout commit
+      if: (env.DOT_COUNT == 2)
+      uses: actions/checkout@v2-beta
+      with:
+        token: ${{ secrets.GH_TOKEN }}
+    - name: Move Application Tags
+      if: (env.DOT_COUNT == 2)
+      run: |
+        $MAJOR_INDEX = $env:TAG_NAME.IndexOf(".")
+        $MINOR_INDEX = $env:TAG_NAME.IndexOf(".", $MAJOR_INDEX + 1)
+        
+        $MAJOR = $env:TAG_NAME.Substring(0, $MAJOR_INDEX)
+        $MINOR = $env:TAG_NAME.Substring(0, $MINOR_INDEX)
+        
+        git tag -f $MAJOR
+        git tag -f $MINOR
+        git push -f --tags


### PR DESCRIPTION
This workflow is to help maintainers maintain the release/tagging strategy.
The idea is that a maintainer can create a release, with the tag in the format `v#.#.#`.
At that same commit, this workflow will move/create the tags `v#.#` and `v#`.
The workflow is not smart and is very literal, if users input garbage it will output garbage.
This is really to work around the fact that users cannot delete/move tags from the user interface.