### PR TITLE
Fixing dotnet compiler Problem Matcher

### DIFF
--- a/.github/csc.json
+++ b/.github/csc.json
@@ -4,9 +4,9 @@
             "owner": "csc",
             "pattern": [
                 {
-                    "regexp": "^([^\\s].*)\\((\\d+|\\d+,\\d+|\\d+,\\d+,\\d+,\\d+)\\):\\s+(error|warning|info)\\s+(\\w+\\d+):\\s*(.*?)\\s+\\[(.*?)\\]$",
+                    "regexp": "^([^\s].*)\((\d+)(?:,\d+|,\d+,\d+)?\):\s+(error|warning)\s+([a-zA-Z]+(?<!MSB)\d+):\s*(.*?)\s+\[(.*?)\]$",
                     "file": 1,
-                    "location": 2,
+                    "line": 2,
                     "severity": 3,
                     "code": 4,
                     "message": 5,

--- a/.github/csc.json
+++ b/.github/csc.json
@@ -4,12 +4,13 @@
             "owner": "csc",
             "pattern": [
                 {
-                    "regexp": "^([^\\s].*)\\((\\d+|\\d+,\\d+|\\d+,\\d+,\\d+,\\d+)\\):\\s+(error|warning|info)\\s+(\\w+\\d+)\\s*:\\s*(.*)$",
+                    "regexp": "^([^\\s].*)\\((\\d+|\\d+,\\d+|\\d+,\\d+,\\d+,\\d+)\\):\\s+(error|warning|info)\\s+(\\w+\\d+):\\s*(.*?)\\s+\\[(.*?)\\]$",
                     "file": 1,
                     "location": 2,
                     "severity": 3,
                     "code": 4,
-                    "message": 5
+                    "message": 5,
+                    "fromPath": 6
                 }
             ]
         }

--- a/.github/csc.json
+++ b/.github/csc.json
@@ -4,7 +4,7 @@
             "owner": "csc",
             "pattern": [
                 {
-                    "regexp": "^([^\s].*)\((\d+)(?:,\d+|,\d+,\d+)?\):\s+(error|warning)\s+([a-zA-Z]+(?<!MSB)\d+):\s*(.*?)\s+\[(.*?)\]$",
+                    "regexp": "^([^\\s].*)\((\\d+)(?:,\\d+|,\\d+,\\d+)?\\):\\s+(error|warning)\\s+([a-zA-Z]+(?<!MSB)\\d+):\\s*(.*?)\\s+\\[(.*?)\\]$",
                     "file": 1,
                     "line": 2,
                     "severity": 3,

--- a/.github/csc.json
+++ b/.github/csc.json
@@ -4,7 +4,7 @@
             "owner": "csc",
             "pattern": [
                 {
-                    "regexp": "^([^\\s].*)\((\\d+)(?:,\\d+|,\\d+,\\d+)?\\):\\s+(error|warning)\\s+([a-zA-Z]+(?<!MSB)\\d+):\\s*(.*?)\\s+\\[(.*?)\\]$",
+                    "regexp": "^([^\\s].*)\\((\\d+)(?:,\\d+|,\\d+,\\d+)?\\):\\s+(error|warning)\\s+([a-zA-Z]+(?<!MSB)\\d+):\\s*(.*?)\\s+\\[(.*?)\\]$",
                     "file": 1,
                     "line": 2,
                     "severity": 3,

--- a/.github/csc.json
+++ b/.github/csc.json
@@ -4,7 +4,7 @@
             "owner": "csc",
             "pattern": [
                 {
-                    "regexp": "^([^\\s].*)\\((\\d+|\\d+,\\d+|\\d+,\\d+,\\d+,\\d+)\\):\\s+(error|warning|info)\\s+(CS\\d+)\\s*:\\s*(.*)$",
+                    "regexp": "^([^\\s].*)\\((\\d+|\\d+,\\d+|\\d+,\\d+,\\d+,\\d+)\\):\\s+(error|warning|info)\\s+(\\w+\\d+)\\s*:\\s*(.*)$",
                     "file": 1,
                     "location": 2,
                     "severity": 3,


### PR DESCRIPTION
1. Adding `fromPath` parameter. Fixes #17 
1. Expand regex to capture code analysis errors/warnings
1. Fixing line identification