### PR TITLE
Updating readme snippets to show latest SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ steps:
 - uses: actions/checkout@master
 - uses: actions/setup-dotnet@v1
   with:
-    dotnet-version: '2.2.103' # SDK Version to use.
+    dotnet-version: '3.1.100' # SDK Version to use.
 - run: dotnet build <my project>
 ```
 
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-16.04
     strategy:
       matrix:
-        dotnet: [ '2.2.103', '3.0.100', '3.1.100-preview1-014459' ]
+        dotnet: [ '2.2.103', '3.0.100', '3.1.100' ]
     name: Dotnet ${{ matrix.dotnet }} sample
     steps:
       - uses: actions/checkout@master
@@ -49,7 +49,7 @@ steps:
 # Authenticates packages to push to GPR
 - uses: actions/setup-dotnet@v1
   with:
-    dotnet-version: '2.2.103' # SDK Version to use.
+    dotnet-version: '3.1.100' # SDK Version to use.
     source-url: https://nuget.pkg.github.com/<owner>/index.json
   env:
     NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
Given the LTS release of .NET Core it's good practice that any samples using the SDK should use the supported versions.  2.2 is no longer a supported version in a month or so and the latest SDK should be used in examples.  Minor change, but important for copy/paste folks.