### PR TITLE
Set osx as the os name

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ${{ matrix.operating-system }}
     strategy:
       matrix:
-        operating-system: [ubuntu-latest, windows-latest]
+        operating-system: [ubuntu-latest, windows-latest, macOS-latest]
     steps:
     - name: Checkout
       uses: actions/checkout@master

--- a/externals/get-os-distro.sh
+++ b/externals/get-os-distro.sh
@@ -113,7 +113,7 @@ get_current_os_name() {
 
     local uname=$(uname)
     if [ "$uname" = "Darwin" ]; then
-        echo "mac"
+        echo "osx"
         return 0
     elif [ "$uname" = "Linux" ]; then
         local linux_platform_name
@@ -139,7 +139,7 @@ get_legacy_os_name() {
 
     local uname=$(uname)
     if [ "$uname" = "Darwin" ]; then
-        echo "mac"
+        echo "osx"
         return 0
     else
         if [ -e /etc/os-release ]; then


### PR DESCRIPTION
With the changes for releases-index, the os mac could no longer be found. This change switches to using osx as the os name which is used in the new json.

Example uses osx-x64, but does not use mac in the version description: https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/3.1/releases.json