### PR TITLE
Remove warning from master branch

### DIFF
--- a/lib/setup-dotnet.js
+++ b/lib/setup-dotnet.js
@@ -26,7 +26,6 @@ function run() {
             // Version is optional.  If supplied, install / use from the tool cache
             // If not supplied then task is still used to setup proxy, auth, etc...
             //
-            console.log(`::warning::Use the v1 tag to get the last version, master may contain breaking changes and will not contain any required packages in the future. i.e. actions/setup-dotnet@v1`);
             let version = core.getInput('version');
             if (!version) {
                 version = core.getInput('dotnet-version');

--- a/src/setup-dotnet.ts
+++ b/src/setup-dotnet.ts
@@ -9,9 +9,6 @@ async function run() {
     // Version is optional.  If supplied, install / use from the tool cache
     // If not supplied then task is still used to setup proxy, auth, etc...
     //
-    console.log(
-      `::warning::Use the v1 tag to get the last version, master may contain breaking changes and will not contain any required packages in the future. i.e. actions/setup-dotnet@v1`
-    );
 
     let version = core.getInput('version');
     if (!version) {


### PR DESCRIPTION
Move back to deploying from master. There are no changes in releases/v1 that needed to be moved back to master.