### PR TITLE
Update csc.json

### DIFF
--- a/.github/csc.json
+++ b/.github/csc.json
@@ -4,7 +4,7 @@
             "owner": "csc",
             "pattern": [
                 {
-                    "regexp": "^([^\\s].*)\\((\\d+)(?:,\\d+|,\\d+,\\d+)?\\):\\s+(error|warning)\\s+([a-zA-Z]+(?<!MSB)\\d+):\\s*(.*?)\\s+\\[(.*?)\\]$",
+                    "regexp": "^([^\s].*)\((\d+)(?:,\d+|,\d+,\d+)?\):\s+(error|warning)\s+([a-zA-Z]+(?<!MSB)\d+):\s*(.*?)\s+\[([^\s]+)[\s\W\dA-z].*\]$",
                     "file": 1,
                     "line": 2,
                     "severity": 3,


### PR DESCRIPTION
The console logger output was changed to allow the user to output multiple properties in an error/warning message. This change would break the fromPath found by the old regular expression. In the brackets, the file path and the properties are now outputted. The new logger format is of the form:

S:\msbuild\src\Build\Evaluation\ExpressionShredder.cs(33,7): error CS1003: Syntax error, ',' expected [S:\msbuild\src\Build\Microsoft.Build.csproj TargetFramework:netcore3.0]

This PR would match the new console output.