### PR TITLE
Support various nuget.config name formats

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -4848,13 +4848,14 @@ function configAuthentication(feedUrl, existingFileLocation = '', processRoot = 
 }
 exports.configAuthentication = configAuthentication;
 function getExistingNugetConfig(processRoot) {
+    const defaultConfigName = 'nuget.config';
     const configFileNames = fs
         .readdirSync(processRoot)
-        .filter(filename => filename.toLowerCase() === 'nuget.config');
+        .filter(filename => filename.toLowerCase() === defaultConfigName);
     if (configFileNames.length) {
         return configFileNames[0];
     }
-    return 'nuget.config';
+    return defaultConfigName;
 }
 function writeFeedToFile(feedUrl, existingFileLocation, tempFileLocation) {
     console.log(`dotnet-auth: Finding any source references in ${existingFileLocation}, writing a new temporary configuration file with credentials to ${tempFileLocation}`);

--- a/dist/index.js
+++ b/dist/index.js
@@ -4840,7 +4840,7 @@ const github = __importStar(__webpack_require__(469));
 const xmlbuilder = __importStar(__webpack_require__(312));
 const xmlParser = __importStar(__webpack_require__(989));
 function configAuthentication(feedUrl, existingFileLocation = '', processRoot = process.cwd()) {
-    const existingNuGetConfig = path.resolve(processRoot, existingFileLocation == ''
+    const existingNuGetConfig = path.resolve(processRoot, existingFileLocation === ''
         ? getExistingNugetConfig(processRoot)
         : existingFileLocation);
     const tempNuGetConfig = path.resolve(processRoot, '../', 'nuget.config');
@@ -4850,7 +4850,7 @@ exports.configAuthentication = configAuthentication;
 function getExistingNugetConfig(processRoot) {
     const configFileNames = fs
         .readdirSync(processRoot)
-        .filter(filename => filename.toLowerCase() == 'nuget.config');
+        .filter(filename => filename.toLowerCase() === 'nuget.config');
     if (configFileNames.length) {
         return configFileNames[0];
     }

--- a/dist/index.js
+++ b/dist/index.js
@@ -4840,11 +4840,22 @@ const github = __importStar(__webpack_require__(469));
 const xmlbuilder = __importStar(__webpack_require__(312));
 const xmlParser = __importStar(__webpack_require__(989));
 function configAuthentication(feedUrl, existingFileLocation = '', processRoot = process.cwd()) {
-    const existingNuGetConfig = path.resolve(processRoot, existingFileLocation == '' ? 'nuget.config' : existingFileLocation);
+    const existingNuGetConfig = path.resolve(processRoot, existingFileLocation == ''
+        ? getExistingNugetConfig(processRoot)
+        : existingFileLocation);
     const tempNuGetConfig = path.resolve(processRoot, '../', 'nuget.config');
     writeFeedToFile(feedUrl, existingNuGetConfig, tempNuGetConfig);
 }
 exports.configAuthentication = configAuthentication;
+function getExistingNugetConfig(processRoot) {
+    const configFileNames = fs
+        .readdirSync(processRoot)
+        .filter(filename => filename.toLowerCase() == 'nuget.config');
+    if (configFileNames.length) {
+        return configFileNames[0];
+    }
+    return 'nuget.config';
+}
 function writeFeedToFile(feedUrl, existingFileLocation, tempFileLocation) {
     console.log(`dotnet-auth: Finding any source references in ${existingFileLocation}, writing a new temporary configuration file with credentials to ${tempFileLocation}`);
     let xml;

--- a/src/authutil.ts
+++ b/src/authutil.ts
@@ -28,13 +28,14 @@ export function configAuthentication(
 }
 
 function getExistingNugetConfig(processRoot: string) {
+  const defaultConfigName = 'nuget.config';
   const configFileNames = fs
     .readdirSync(processRoot)
-    .filter(filename => filename.toLowerCase() === 'nuget.config');
+    .filter(filename => filename.toLowerCase() === defaultConfigName);
   if (configFileNames.length) {
     return configFileNames[0];
   }
-  return 'nuget.config';
+  return defaultConfigName;
 }
 
 function writeFeedToFile(

--- a/src/authutil.ts
+++ b/src/authutil.ts
@@ -13,7 +13,7 @@ export function configAuthentication(
 ) {
   const existingNuGetConfig: string = path.resolve(
     processRoot,
-    existingFileLocation == ''
+    existingFileLocation === ''
       ? getExistingNugetConfig(processRoot)
       : existingFileLocation
   );
@@ -30,7 +30,7 @@ export function configAuthentication(
 function getExistingNugetConfig(processRoot: string) {
   const configFileNames = fs
     .readdirSync(processRoot)
-    .filter(filename => filename.toLowerCase() == 'nuget.config');
+    .filter(filename => filename.toLowerCase() === 'nuget.config');
   if (configFileNames.length) {
     return configFileNames[0];
   }

--- a/src/authutil.ts
+++ b/src/authutil.ts
@@ -13,7 +13,7 @@ export function configAuthentication(
 ) {
   const existingNuGetConfig: string = path.resolve(
     processRoot,
-    existingFileLocation == '' ? 'nuget.config' : existingFileLocation
+    existingFileLocation == '' ? getExistingNugetConfig(processRoot) : existingFileLocation
   );
 
   const tempNuGetConfig: string = path.resolve(
@@ -23,6 +23,14 @@ export function configAuthentication(
   );
 
   writeFeedToFile(feedUrl, existingNuGetConfig, tempNuGetConfig);
+}
+
+function getExistingNugetConfig(processRoot: string) {
+  const configFileNames = fs.readdirSync(processRoot).filter(filename => filename.toLowerCase() == 'nuget.config')
+  if (configFileNames.length) {
+    return configFileNames[0];
+  }
+  return 'nuget.config';
 }
 
 function writeFeedToFile(

--- a/src/authutil.ts
+++ b/src/authutil.ts
@@ -13,7 +13,9 @@ export function configAuthentication(
 ) {
   const existingNuGetConfig: string = path.resolve(
     processRoot,
-    existingFileLocation == '' ? getExistingNugetConfig(processRoot) : existingFileLocation
+    existingFileLocation == ''
+      ? getExistingNugetConfig(processRoot)
+      : existingFileLocation
   );
 
   const tempNuGetConfig: string = path.resolve(
@@ -26,7 +28,9 @@ export function configAuthentication(
 }
 
 function getExistingNugetConfig(processRoot: string) {
-  const configFileNames = fs.readdirSync(processRoot).filter(filename => filename.toLowerCase() == 'nuget.config')
+  const configFileNames = fs
+    .readdirSync(processRoot)
+    .filter(filename => filename.toLowerCase() == 'nuget.config');
   if (configFileNames.length) {
     return configFileNames[0];
   }


### PR DESCRIPTION
**Description:**
The task finds Nuget config file with name `nuget.config` in root directory by default. Added a possibility to use various formats for file name: `NuGet.config`, `NuGet.Config` without specifying `config-file` input explicitly.

**Related issue:**
#181 

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.