### PR TITLE
Add workaround to fix BOM-related error  during parsing global.json

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -7829,7 +7829,9 @@ function run() {
                 core.debug('No version found, trying to find version from global.json');
                 const globalJsonPath = path.join(process.cwd(), 'global.json');
                 if (fs.existsSync(globalJsonPath)) {
-                    const globalJson = JSON.parse(fs.readFileSync(globalJsonPath, { encoding: 'utf8' }));
+                    const globalJson = JSON.parse(
+                    // .trim() is necessary to strip BOM https://github.com/nodejs/node/issues/20649
+                    fs.readFileSync(globalJsonPath, { encoding: 'utf8' }).trim());
                     if (globalJson.sdk && globalJson.sdk.version) {
                         version = globalJson.sdk.version;
                     }

--- a/src/setup-dotnet.ts
+++ b/src/setup-dotnet.ts
@@ -20,7 +20,8 @@ export async function run() {
       const globalJsonPath = path.join(process.cwd(), 'global.json');
       if (fs.existsSync(globalJsonPath)) {
         const globalJson = JSON.parse(
-          fs.readFileSync(globalJsonPath, {encoding: 'utf8'})
+          // .trim() is necessary to strip BOM https://github.com/nodejs/node/issues/20649
+          fs.readFileSync(globalJsonPath, {encoding: 'utf8'}).trim()
         );
         if (globalJson.sdk && globalJson.sdk.version) {
           version = globalJson.sdk.version;


### PR DESCRIPTION
**Description:**
Parsing of the global.json fail if its saved with BOM

**Related issue:**
https://github.com/actions/setup-dotnet/issues/185

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.