### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ steps:
 - uses: actions/setup-dotnet@v1
   with:
     dotnet-version: 3.1.x
-- name: Publish the package to NuGet Org
+- name: Publish the package to nuget.org
   run: dotnet nuget push */bin/Release/*.nupkg -k $NUGET_AUTH_TOKEN -s https://api.nuget.org/v3/index.json
   env:
     NUGET_AUTH_TOKEN: ${{ secrets.NUGET_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ steps:
 - name: Publish the package to GPR
   run: dotnet nuget push <my project>/bin/Release/*.nupkg
 
-# Authticates packages to push to Azure Artifacts
+# Authenticates packages to push to Azure Artifacts
 - uses: actions/setup-dotnet@v1
   with:
     source-url: https://pkgs.dev.azure.com/<your-organization>/_packaging/<your-feed-name>/nuget/v3/index.json
@@ -105,7 +105,8 @@ steps:
 - name: Publish the package to Azure Artifacts
   run: dotnet nuget push <my project>/bin/Release/*.nupkg
 
-# Authticates packages to push to NuGet Org
+# Authenticates packages to push to nuget.org.
+# It's only the way to push a package to nuget.org feed for macOS/Linus machines due to API key config store limitations.
 - uses: actions/setup-dotnet@v1
   with:
     dotnet-version: 3.1.x

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ steps:
 - run: dotnet build <my project>
 - name: Create the package
   run: dotnet pack --configuration Release <my project>
- - name: Publish the package to GPR
+- name: Publish the package to GPR
   run: dotnet nuget push <my project>/bin/Release/*.nupkg
 
 # Authticates packages to push to Azure Artifacts
@@ -104,6 +104,15 @@ steps:
     NUGET_AUTH_TOKEN: ${{secrets.AZURE_DEVOPS_PAT}} # Note, create a secret with this name in Settings
 - name: Publish the package to Azure Artifacts
   run: dotnet nuget push <my project>/bin/Release/*.nupkg
+
+# Authticates packages to push to NuGet Org
+- uses: actions/setup-dotnet@v1
+  with:
+    dotnet-version: 3.1.x
+- name: Publish the package to NuGet Org
+  run: dotnet nuget push */bin/Release/*.nupkg -k $NUGET_AUTH_TOKEN -s https://api.nuget.org/v3/index.json
+  env:
+    NUGET_AUTH_TOKEN: ${{ secrets.NUGET_TOKEN }}
 ```
 
 ## Environment Variables to use with dotnet

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ steps:
   run: dotnet nuget push <my project>/bin/Release/*.nupkg
 
 # Authenticates packages to push to nuget.org.
-# It's only the way to push a package to nuget.org feed for macOS/Linus machines due to API key config store limitations.
+# It's only the way to push a package to nuget.org feed for macOS/Linux machines due to API key config store limitations.
 - uses: actions/setup-dotnet@v1
   with:
     dotnet-version: 3.1.x


### PR DESCRIPTION
**Description:**
According to nuget.org documentation it is not possible to pass API Token using nuget.config file for Linux or MacOS, and only the way is to use direct -k and -s options for dotnet nuget push command.

[Documentation link](https://github.com/NuGet/Home/pull/10658)
**Related issue:**
https://github.com/actions/setup-dotnet/issues/190

**Check list:**
- [+] Mark if documentation changes are required.
- [+] Mark if tests were added or updated to cover the changes.