### PR TITLE
Added run-restore option.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,9 @@ inputs:
   include-prerelease:
     description: 'Whether prerelease versions should be matched with non-exact versions (for example 5.0.0-preview.6 being matched by 5, 5.0, 5.x or 5.0.x). Defaults to false if not provided.'
     required: False
+  run-restore:
+    description: 'Optionally run dotnet restore on the project after the target .NET SDK is installed.'
+    required: False
 runs:
   using: 'node12'
   main: 'dist/index.js'


### PR DESCRIPTION
**Description:**
Added ``run-restore`` configuration option to run ``dotnet restore`` for the users of this action so they can benefit from a more faster CI then (``dotnet restore`` will only do things only when the restored outputs are outdated and needs to be updated then it updates it automatically with dependency updates). However I would set it up to only cache them on non-PR runs however so it should be nothing major when adding this to this action (it just cleans up a ton of people's workflows and needing to remember to explicitly copy and paste their ``dotnet restore`` steps which is *much* more easier to just set the option on this action and have it take care of the rest using powershell that is xplat.

**Related issue:**
Fixes https://github.com/actions/setup-dotnet/issues/199.

**Check list:**
- [x] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.

Documentation changes, and tests might need to be added.