### PR TITLE
Move toolcache folder

### DIFF
--- a/__tests__/clear-toolcache.ps1
+++ b/__tests__/clear-toolcache.ps1
@@ -1,13 +1,13 @@
 $dotnetPaths = @{
-    Linux = @("/usr/share/dotnet")
-    macOS = @("$env:HOME/.dotnet")
-    Windows = @("$env:ProgramFiles\dotnet/*",
-                  "$env:LocalAppData\Microsoft\dotnet/*")
+    Linux = "/usr/share/dotnet"
+    macOS = "$env:HOME/.dotnet"
+    Windows = "$env:ProgramFiles\dotnet", "$env:LocalAppData\Microsoft\dotnet"
 }
 
-foreach ($path in $dotnetPaths[$args[0]]) {
-    if (Test-Path $path) {
-        Write-Host "Clear $path path"
-        Remove-Item $path -Recurse -Force
+foreach ($srcPath in $dotnetPaths[$args[0]]) {
+    if (Test-Path $srcPath) {
+        Write-Host "Move $srcPath path"
+        $dstPath = Join-Path ([IO.Path]::GetTempPath()) ([IO.Path]::GetRandomFileName())
+        Move-Item -Path $srcPath -Destination $dstPath
     }
 }


### PR DESCRIPTION
**Description:**
Clear toolcache step takes  more than ~9 minutes for Windows. To save time we should use move instead of remove operation.
![image](https://user-images.githubusercontent.com/47745270/123607306-6d4b8000-d806-11eb-905a-22efb0d7aac6.png)
