### PR TITLE
Warn users when installing EOL .NET versions

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -17089,7 +17089,7 @@ class DotnetCoreInstaller {
             }
             const releaseInfo = releasesInfo[0];
             if (releaseInfo['support-phase'] === 'eol') {
-                core.warning(`${releaseInfo['product']} ${releaseInfo['channel-version']} is no longer supported and may not work properly.`);
+                core.warning(`${releaseInfo['product']} ${releaseInfo['channel-version']} is no longer supported and will not receive security updates in the future. Please refer to https://aka.ms/dotnet-core-support for more information about the .NET support policy.`);
             }
             return releaseInfo['releases.json'];
         });

--- a/dist/index.js
+++ b/dist/index.js
@@ -17087,7 +17087,11 @@ class DotnetCoreInstaller {
             if (releasesInfo.length === 0) {
                 throw new Error(`Could not find info for version ${versionParts.join('.')} at ${DotNetCoreIndexUrl}`);
             }
-            return releasesInfo[0]['releases.json'];
+            const releaseInfo = releasesInfo[0];
+            if (releaseInfo['support-phase'] === 'eol') {
+                core.warning(`${releaseInfo['product']} ${releaseInfo['channel-version']} is no longer supported and may not work properly.`);
+            }
+            return releaseInfo['releases.json'];
         });
     }
 }

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -283,7 +283,14 @@ export class DotnetCoreInstaller {
       );
     }
 
-    return releasesInfo[0]['releases.json'];
+    const releaseInfo = releasesInfo[0];
+    if (releaseInfo['support-phase'] === 'eol') {
+      core.warning(
+        `${releaseInfo['product']} ${releaseInfo['channel-version']} is no longer supported and may not work properly.`
+      );
+    }
+
+    return releaseInfo['releases.json'];
   }
 
   private version: string;

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -286,7 +286,8 @@ export class DotnetCoreInstaller {
     const releaseInfo = releasesInfo[0];
     if (releaseInfo['support-phase'] === 'eol') {
       core.warning(
-        `${releaseInfo['product']} ${releaseInfo['channel-version']} is no longer supported and may not work properly.`
+        `${releaseInfo['product']} ${releaseInfo['channel-version']} is no longer supported and will not receive security updates in the future. Please refer to https://aka.ms/dotnet-core-support for more information about the .NET support policy.`
+
       );
     }
 

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -287,7 +287,6 @@ export class DotnetCoreInstaller {
     if (releaseInfo['support-phase'] === 'eol') {
       core.warning(
         `${releaseInfo['product']} ${releaseInfo['channel-version']} is no longer supported and will not receive security updates in the future. Please refer to https://aka.ms/dotnet-core-support for more information about the .NET support policy.`
-
       );
     }
 


### PR DESCRIPTION
**Description:**
Implements a warning when users try to install an EOL version of .NET.

**Related issue:**
Closes #180

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.