### PR TITLE
Use `core.getBooleanInput()` to resolve `include-prerelease` option

### DIFF
--- a/__tests__/setup-dotnet.test.ts
+++ b/__tests__/setup-dotnet.test.ts
@@ -16,6 +16,7 @@ describe('setup-dotnet tests', () => {
     process.env.RUNNER_TOOL_CACHE = toolDir;
     process.env.DOTNET_INSTALL_DIR = toolDir;
     process.env.RUNNER_TEMP = tempDir;
+    process.env['INPUT_INCLUDE-PRERELEASE'] = 'false';
     await io.rmRF(toolDir);
     await io.rmRF(tempDir);
   });

--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,7 @@ inputs:
   include-prerelease:
     description: 'Whether prerelease versions should be matched with non-exact versions (for example 5.0.0-preview.6 being matched by 5, 5.0, 5.x or 5.0.x). Defaults to false if not provided.'
     required: False
+    default: 'false'
 runs:
   using: 'node16'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -478,8 +478,7 @@ function run() {
                 }
             }
             if (versions.length) {
-                const includePrerelease = (core.getInput('include-prerelease') || 'false').toLowerCase() ===
-                    'true';
+                const includePrerelease = core.getBooleanInput('include-prerelease');
                 let dotnetInstaller;
                 for (const version of new Set(versions)) {
                     dotnetInstaller = new installer.DotnetCoreInstaller(version, includePrerelease);

--- a/src/setup-dotnet.ts
+++ b/src/setup-dotnet.ts
@@ -38,9 +38,9 @@ export async function run() {
     }
 
     if (versions.length) {
-      const includePrerelease: boolean =
-        (core.getInput('include-prerelease') || 'false').toLowerCase() ===
-        'true';
+      const includePrerelease: boolean = core.getBooleanInput(
+        'include-prerelease'
+      );
       let dotnetInstaller!: installer.DotnetCoreInstaller;
       for (const version of new Set<string>(versions)) {
         dotnetInstaller = new installer.DotnetCoreInstaller(


### PR DESCRIPTION
**Description:**
`getBooleanInput()` function was added since @actions/core@1.3.0 (actions/toolkit#725).
This PR uses it to reduce code path.

:warning:This change is **BREAKING CHANGE** if `include-prerelease` set invalid value.
```yaml
- uses: actions/setup-dotnet@v1
  with:
    dotnet-version: '6.0.x'
    include-prerelease: 'foo' # Resolved 'false' before, but throws error now
```

**Related issue:**
None.

**Check list:**
- [x] Mark if documentation changes are required.
- [x] Mark if tests were added or updated to cover the changes.