### PR TITLE
avoid installing the same version multiple times

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -8687,7 +8687,7 @@ function run() {
                 const includePrerelease = (core.getInput('include-prerelease') || 'false').toLowerCase() ===
                     'true';
                 let dotnetInstaller;
-                for (const version of versions) {
+                for (const version of new Set(versions)) {
                     dotnetInstaller = new installer.DotnetCoreInstaller(version, includePrerelease);
                     yield dotnetInstaller.installDotnet();
                 }

--- a/src/setup-dotnet.ts
+++ b/src/setup-dotnet.ts
@@ -28,7 +28,7 @@ export async function run() {
         (core.getInput('include-prerelease') || 'false').toLowerCase() ===
         'true';
       let dotnetInstaller!: installer.DotnetCoreInstaller;
-      for (const version of versions) {
+      for (const version of new Set<string>(versions)) {
         dotnetInstaller = new installer.DotnetCoreInstaller(
           version,
           includePrerelease


### PR DESCRIPTION
**Description:**

I have workflows which install both a fixed version of the SDK and a secondary SDK, for testing purposes, specified by a matrix entry. Sometimes, the fixed version and the matrix version are the same. In those cases, I don't want to try and install the same SDK twice. This PR solves this by ignoring duplicate versions in the action.

**Related issue:**

None.

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.