### PR TITLE
add global-json-file input

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -163,6 +163,32 @@ jobs:
         shell: pwsh
         run: __tests__/verify-dotnet.ps1 3.1 2.2
 
+  test-setup-global-json-specified-and-version:
+    runs-on: ${{ matrix.operating-system }}
+    strategy:
+      fail-fast: false
+      matrix:
+        operating-system: [ubuntu-latest, windows-latest, macOS-latest]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Clear toolcache
+        shell: pwsh
+        run: __tests__/clear-toolcache.ps1 ${{ runner.os }}
+      - name: Write global.json
+        shell: bash
+        run: |
+          mkdir subdirectory
+          echo '{"sdk":{"version": "2.2","rollForward": "latestFeature"}}' > ./subdirectory/global.json
+      - name: Setup dotnet
+        uses: ./
+        with:
+          dotnet-version: 3.1
+          global-json-file: ./subdirectory/global.json
+      - name: Verify dotnet
+        shell: pwsh
+        run: __tests__/verify-dotnet.ps1 2.2 3.1
+
   test-proxy:
     runs-on: ubuntu-latest
     container:

--- a/README.md
+++ b/README.md
@@ -51,6 +51,16 @@ steps:
     include-prerelease: true
 - run: dotnet build <my project>
 ```
+global.json in a subdirectory:
+```yml
+steps:
+- uses: actions/checkout@v3
+- uses: actions/setup-dotnet@v2
+  with:
+    global-json-file: csharp/global.json
+- run: dotnet build <my project>
+  working-directory: csharp
+```
 
 Matrix Testing:
 ```yaml

--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ inputs:
   dotnet-version:
     description: 'Optional SDK version(s) to use. If not provided, will install global.json version when available. Examples: 2.2.104, 3.1, 3.1.x'
   global-json-file:
-    description: 'Optional global.json location, if your global.json it''t located in the root of the repo.'
+    description: 'Optional global.json location, if your global.json isn''t located in the root of the repo.'
   source-url:
     description: 'Optional package source for which to set up authentication. Will consult any existing NuGet.config in the root of the repo and provide a temporary NuGet.config using the NUGET_AUTH_TOKEN environment variable as a ClearTextPassword'
   owner:

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,8 @@ branding:
 inputs:
   dotnet-version:
     description: 'Optional SDK version(s) to use. If not provided, will install global.json version when available. Examples: 2.2.104, 3.1, 3.1.x'
+  global-json-file:
+    description: 'Optional global.json location, if your global.json it''t located in the root of the repo.'
   source-url:
     description: 'Optional package source for which to set up authentication. Will consult any existing NuGet.config in the root of the repo and provide a temporary NuGet.config using the NUGET_AUTH_TOKEN environment variable as a ClearTextPassword'
   owner:

--- a/dist/index.js
+++ b/dist/index.js
@@ -9115,11 +9115,21 @@ function run() {
             //
             // dotnet-version is optional, but needs to be provided for most use cases.
             // If supplied, install / use from the tool cache.
+            // global-version-file may be specified to point to a specific global.json
+            // and will be used to install an additional version.
             // If not supplied, look for version in ./global.json.
             // If a valid version still can't be identified, nothing will be installed.
             // Proxy, auth, (etc) are still set up, even if no version is identified
             //
             let versions = core.getMultilineInput('dotnet-version');
+            const globalJsonFileInput = core.getInput('global-json-file');
+            if (globalJsonFileInput) {
+                const globalJsonPath = path.join(process.cwd(), globalJsonFileInput);
+                if (!fs.existsSync(globalJsonPath)) {
+                    throw new Error(`The specified global.json file '${globalJsonFileInput}' does not exist`);
+                }
+                versions.push(getVersionFromGlobalJson(globalJsonPath));
+            }
             if (!versions.length) {
                 // Try to fall back to global.json
                 core.debug('No version found, trying to find version from global.json');

--- a/src/setup-dotnet.ts
+++ b/src/setup-dotnet.ts
@@ -9,11 +9,25 @@ export async function run() {
     //
     // dotnet-version is optional, but needs to be provided for most use cases.
     // If supplied, install / use from the tool cache.
+    // global-version-file may be specified to point to a specific global.json
+    // and will be used to install an additional version.
     // If not supplied, look for version in ./global.json.
     // If a valid version still can't be identified, nothing will be installed.
     // Proxy, auth, (etc) are still set up, even if no version is identified
     //
     let versions = core.getMultilineInput('dotnet-version');
+
+    const globalJsonFileInput = core.getInput('global-json-file');
+    if (globalJsonFileInput) {
+      const globalJsonPath = path.join(process.cwd(), globalJsonFileInput);
+      if (!fs.existsSync(globalJsonPath)) {
+        throw new Error(
+          `The specified global.json file '${globalJsonFileInput}' does not exist`
+        );
+      }
+      versions.push(getVersionFromGlobalJson(globalJsonPath));
+    }
+
     if (!versions.length) {
       // Try to fall back to global.json
       core.debug('No version found, trying to find version from global.json');


### PR DESCRIPTION
**Description:**
Our workflow involves doing a checkout to the subdirectory of the workspace. This results in a similar situation to that described in #253, where the global.json is not present in the root of the workspace.

This PR proposes solving this with a `global-json-file` input, similar to [`node-version-file` from actions/setup-node](https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#node-version-file).

* Unlike `node-version-file`, `global-json-file` can be used alongside `dotnet-version` since multiple versions are already allowed.
* If `global-json-file` is specified, it is an error for it not to exist.
* As before, if `global-json-file` is not specified `./global.json` is still searched, but only if `dotnet-version` was not, and the debug message of _No version found, trying to find version from global.json_ is still printed.

I've updated the documentation with the new input.

I've not added tests as there is not an existing framework for specifying inputs and I did not feel I should significantly refactor anything to do so. The existing tests pass and show the fallback to `./global.json` still works as expected.

**Related issue:**
Similar to https://github.com/actions/setup-dotnet/issues/253

**Check list:**
- [x] Mark if documentation changes are required.
- [x] Mark if tests were added or updated to cover the changes.


Happy Friday and hope you have a good weekend!