### PR TITLE
Update vulnerable packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3694,9 +3694,9 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "node_modules/ms": {
@@ -4640,12 +4640,12 @@
       }
     },
     "node_modules/wget-improved": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/wget-improved/-/wget-improved-3.2.1.tgz",
-      "integrity": "sha512-bZmRufYav/OFRdS8LerCbzP3b/L8tjRwqap6NhqcvEAfZrBMFwqjtFzbVk2gutEWdG78WKJgIn9yveI+ENQSlA==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/wget-improved/-/wget-improved-3.3.1.tgz",
+      "integrity": "sha512-OF22MM9ImbOcuB5ZV3ye0q1udaYeTP/V6LOfjNyGCNNC7bGB219ljZv6Wk5mPogeigJJ6CqheLScv17AFbsdGA==",
       "dev": true,
       "dependencies": {
-        "minimist": "1.2.5",
+        "minimist": "1.2.6",
         "tunnel": "0.0.6"
       },
       "bin": {
@@ -7698,9 +7698,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "ms": {
@@ -8405,12 +8405,12 @@
       "dev": true
     },
     "wget-improved": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/wget-improved/-/wget-improved-3.2.1.tgz",
-      "integrity": "sha512-bZmRufYav/OFRdS8LerCbzP3b/L8tjRwqap6NhqcvEAfZrBMFwqjtFzbVk2gutEWdG78WKJgIn9yveI+ENQSlA==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/wget-improved/-/wget-improved-3.3.1.tgz",
+      "integrity": "sha512-OF22MM9ImbOcuB5ZV3ye0q1udaYeTP/V6LOfjNyGCNNC7bGB219ljZv6Wk5mPogeigJJ6CqheLScv17AFbsdGA==",
       "dev": true,
       "requires": {
-        "minimist": "1.2.5",
+        "minimist": "1.2.6",
         "tunnel": "0.0.6"
       }
     },


### PR DESCRIPTION
**Description:**
Dependabot cannot update vulnerable package `minimist` automatically:

https://github.com/actions/setup-dotnet/security/dependabot

<img width="1105" alt="Screenshot 2022-04-21 at 11 15 03 AM" src="https://user-images.githubusercontent.com/7628945/164423298-d1a2fc3f-d8d4-4a85-b0eb-5eca085c95c9.png">

Updated manually.