### PR TITLE
Enable console color output by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,10 @@ Some environment variables may be necessary for your particular case or to impro
 - DOTNET_CLI_TELEMETRY_OPTOUT - opt-out of telemetry being sent to Microsoft (default: false)
 - DOTNET_MULTILEVEL_LOOKUP - configures whether the global install location is used as a fall-back (default: true)
 
+**Note** Sets `DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION` and `TERM` to force color output by default (https://github.com/actions/setup-dotnet/issues/288).
+- DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION = true
+- TERM = xterm
+
 Example usage:
 ```yaml
 build:

--- a/dist/index.js
+++ b/dist/index.js
@@ -339,6 +339,10 @@ class DotnetCoreInstaller {
         }
         console.log(process.env['PATH']);
     }
+    static enableConsoleColorOutput() {
+        core.exportVariable('DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION', 'true');
+        core.exportVariable('TERM', 'xterm');
+    }
     // versionInfo - versionInfo of the SDK/Runtime
     resolveVersion(versionInfo) {
         return __awaiter(this, void 0, void 0, function* () {
@@ -486,6 +490,7 @@ function run() {
                     yield dotnetInstaller.installDotnet();
                 }
                 installer.DotnetCoreInstaller.addToPath();
+                installer.DotnetCoreInstaller.enableConsoleColorOutput();
             }
             const sourceUrl = core.getInput('source-url');
             const configFile = core.getInput('config-file');

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -197,6 +197,11 @@ export class DotnetCoreInstaller {
     console.log(process.env['PATH']);
   }
 
+  static enableConsoleColorOutput() {
+    core.exportVariable('DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION', 'true');
+    core.exportVariable('TERM', 'xterm');
+  }
+
   // versionInfo - versionInfo of the SDK/Runtime
   async resolveVersion(versionInfo: DotNetVersionInfo): Promise<string> {
     if (versionInfo.isExactVersion()) {

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -198,7 +198,10 @@ export class DotnetCoreInstaller {
   }
 
   static enableConsoleColorOutput() {
-    core.exportVariable('DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION', 'true');
+    core.exportVariable(
+      'DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION',
+      'true'
+    );
     core.exportVariable('TERM', 'xterm');
   }
 

--- a/src/setup-dotnet.ts
+++ b/src/setup-dotnet.ts
@@ -50,6 +50,7 @@ export async function run() {
         await dotnetInstaller.installDotnet();
       }
       installer.DotnetCoreInstaller.addToPath();
+      installer.DotnetCoreInstaller.enableConsoleColorOutput();
     }
 
     const sourceUrl: string = core.getInput('source-url');


### PR DESCRIPTION
**Description:**
Set environment variables `DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION` and `TERM` to enable color output by default.

Build via current `setup-dotnet`: https://github.com/vsafonkin/dotnet-setup-test/actions/runs/2265449492

<img width="919" alt="Screenshot 2022-05-03 at 7 55 45 PM" src="https://user-images.githubusercontent.com/7628945/166515370-3c41cc2a-4ffb-4d4b-9671-505fcb562bda.png">

Build via `setup-dotnet` from PR branch: https://github.com/vsafonkin/dotnet-setup-test/runs/6278013678

<img width="912" alt="Screenshot 2022-05-03 at 7 58 40 PM" src="https://user-images.githubusercontent.com/7628945/166515798-c5bc5319-5821-4b19-8934-08497a8ddfee.png">

**Related issue:**
#288 

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.