### PR TITLE
Fix husky config to resolve git hook error

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -30,7 +30,7 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Rebuild the dist/ directory
         run: npm run build

--- a/.github/workflows/licensed.yml
+++ b/.github/workflows/licensed.yml
@@ -15,7 +15,7 @@ jobs:
     name: Check licenses
     steps:
       - uses: actions/checkout@v3
-      - run: npm ci
+      - run: npm ci --ignore-scripts
       - name: Install licensed
         run: |
           cd $RUNNER_TEMP

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -26,14 +26,14 @@ jobs:
       with:
         node-version: 16.x
         cache: npm
-    - run: npm ci
+    - run: npm ci --ignore-scripts
     - run: npm run build
     - run: npm run format-check
     - run: npm test
     - name: Verify no unstaged changes
       if: runner.os != 'windows'
       run: __tests__/verify-no-unstaged-changes.sh
-  
+
   test-setup-multiple-versions:
     runs-on: ${{ matrix.operating-system }}
     strategy:
@@ -50,9 +50,9 @@ jobs:
         uses: ./
         with:
           dotnet-version: |
-             2.2.402
-             3.1.404
-             3.0.x
+            2.2.402
+            3.1.404
+            3.0.x
       - name: Verify dotnet
         shell: pwsh
         run: __tests__/verify-dotnet.ps1 2.2.402 3.1.404 '3.0'
@@ -114,7 +114,7 @@ jobs:
       - name: Verify dotnet
         shell: pwsh
         run: __tests__/verify-dotnet.ps1 3.1 2.2
-  
+
   test-setup-latest-patch-version:
     runs-on: ${{ matrix.operating-system }}
     strategy:

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npm run format

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+# Tests are not run at push time since they can take 2-4 minutes to complete
+npm run format-check

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@types/node": "^16.11.25",
         "@types/semver": "^6.2.2",
         "@vercel/ncc": "^0.33.4",
-        "husky": "^7.0.2",
+        "husky": "^8.0.1",
         "jest": "^27.2.5",
         "jest-circus": "^27.2.5",
         "prettier": "^1.19.1",
@@ -2305,15 +2305,15 @@
       }
     },
     "node_modules/husky": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-7.0.2.tgz",
-      "integrity": "sha512-8yKEWNX4z2YsofXAMT7KvA1g8p+GxtB1ffV8XtpAEGuXNAbCV5wdNKH+qTpw8SM9fh4aMPDR+yQuKfgnreyZlg==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.1.tgz",
+      "integrity": "sha512-xs7/chUH/CKdOCs7Zy0Aev9e/dKOMZf3K1Az1nar3tzlv0jfqnYtu235bstsWTmXOR0EfINrPa97yy4Lz6RiKw==",
       "dev": true,
       "bin": {
         "husky": "lib/bin.js"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/sponsors/typicode"
@@ -6645,9 +6645,9 @@
       "dev": true
     },
     "husky": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-7.0.2.tgz",
-      "integrity": "sha512-8yKEWNX4z2YsofXAMT7KvA1g8p+GxtB1ffV8XtpAEGuXNAbCV5wdNKH+qTpw8SM9fh4aMPDR+yQuKfgnreyZlg==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.1.tgz",
+      "integrity": "sha512-xs7/chUH/CKdOCs7Zy0Aev9e/dKOMZf3K1Az1nar3tzlv0jfqnYtu235bstsWTmXOR0EfINrPa97yy4Lz6RiKw==",
       "dev": true
     },
     "iconv-lite": {

--- a/package.json
+++ b/package.json
@@ -8,15 +8,9 @@
     "build": "tsc && ncc build",
     "format": "prettier --write **/*.ts",
     "format-check": "prettier --check **/*.ts",
+    "prepare": "husky install",
     "test": "jest",
     "update-installers": "nwget https://dot.net/v1/dotnet-install.ps1 -O externals/install-dotnet.ps1 && nwget https://dot.net/v1/dotnet-install.sh -O externals/install-dotnet.sh"
-  },
-  "husky": {
-    "hooks": {
-      "//": "Tests are not run at push time since they can take 2-4 minutes to complete",
-      "pre-commit": "npm run format",
-      "pre-push": "npm run format-check"
-    }
   },
   "repository": {
     "type": "git",
@@ -44,7 +38,7 @@
     "@types/node": "^16.11.25",
     "@types/semver": "^6.2.2",
     "@vercel/ncc": "^0.33.4",
-    "husky": "^7.0.2",
+    "husky": "^8.0.1",
     "jest": "^27.2.5",
     "jest-circus": "^27.2.5",
     "prettier": "^1.19.1",


### PR DESCRIPTION
**Description:**
Upgrading [husky](https://github.com/typicode/husky) from v4 to v5 or above requires migrating previous config.
But this repo does not, and causes git hook errors.

This PR migrates husky to v8 following [official guide](https://typicode.github.io/husky/#/?id=migrate-from-v4-to-v8).

**Related issue:**
None

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.