### PR TITLE
Add support for Windows-arm

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -275,7 +275,10 @@ class DotnetCoreInstaller {
                     command += ` -ProxyBypassList ${process.env['no_proxy']}`;
                 }
                 // process.env must be explicitly passed in for DOTNET_INSTALL_DIR to be used
-                const powershellPath = yield io.which('powershell', true);
+                let powershellPath = yield io.which('pwsh', false);
+                if (powershellPath == '') {
+                    powershellPath = yield io.which('powershell', true);
+                }
                 var options = {
                     listeners: {
                         stdout: (data) => {

--- a/dist/index.js
+++ b/dist/index.js
@@ -275,10 +275,7 @@ class DotnetCoreInstaller {
                     command += ` -ProxyBypassList ${process.env['no_proxy']}`;
                 }
                 // process.env must be explicitly passed in for DOTNET_INSTALL_DIR to be used
-                let powershellPath = yield io.which('pwsh', false);
-                if (powershellPath == '') {
-                    powershellPath = yield io.which('powershell', true);
-                }
+                const powershellPath = (yield io.which('pwsh', false)) || (yield io.which('powershell', true));
                 var options = {
                     listeners: {
                         stdout: (data) => {

--- a/externals/install-dotnet.sh
+++ b/externals/install-dotnet.sh
@@ -354,6 +354,48 @@ get_normalized_architecture_from_architecture() {
 }
 
 # args:
+# version - $1
+# channel - $2
+# architecture - $3
+get_normalized_architecture_for_specific_sdk_version() {
+    eval $invocation
+
+    local is_version_support_arm64="$(is_arm64_supported "$1")"
+    local is_channel_support_arm64="$(is_arm64_supported "$2")"
+    local architecture="$3";
+    local osname="$(get_current_os_name)"
+
+    if [ "$osname" == "osx" ] && [ "$architecture" == "arm64" ] && { [ "$is_version_support_arm64" = false ] || [ "$is_channel_support_arm64" = false ]; }; then
+        #check if rosetta is installed
+        if [ "$(/usr/bin/pgrep oahd >/dev/null 2>&1;echo $?)" -eq 0 ]; then 
+            say_verbose "Changing user architecture from '$architecture' to 'x64' because .NET SDKs prior to version 6.0 do not support arm64." 
+            echo "x64"
+            return 0;
+        else
+            say_err "Architecture \`$architecture\` is not supported for .NET SDK version \`$version\`. Please install Rosetta to allow emulation of the \`$architecture\` .NET SDK on this platform"
+            return 1
+        fi
+    fi
+
+    echo "$architecture"
+    return 0
+}
+
+# args:
+# version or channel - $1
+is_arm64_supported() {
+    #any channel or version that starts with the specified versions
+    case "$1" in
+        ( "1"* | "2"* | "3"*  | "4"* | "5"*) 
+            echo false
+            return 0
+    esac
+
+    echo true
+    return 0
+}
+
+# args:
 # user_defined_os - $1
 get_normalized_os() {
     eval $invocation
@@ -523,7 +565,7 @@ parse_globaljson_file_for_version() {
         return 1
     fi
 
-    sdk_section=$(cat $json_file | awk '/"sdk"/,/}/')
+    sdk_section=$(cat $json_file | tr -d "\r" | awk '/"sdk"/,/}/')
     if [ -z "$sdk_section" ]; then
         say_err "Unable to parse the SDK node in \`$json_file\`"
         return 1
@@ -988,8 +1030,6 @@ download() {
         sleep $((attempts*10))
     done
 
-
-
     if [ "$failed" = true ]; then
         say_verbose "Download failed: $remote_path"
         return 1
@@ -1345,6 +1385,8 @@ calculate_vars() {
     say_verbose "Normalized product: '$normalized_product'."
     install_root="$(resolve_installation_path "$install_dir")"
     say_verbose "InstallRoot: '$install_root'."
+
+    normalized_architecture="$(get_normalized_architecture_for_specific_sdk_version "$version" "$normalized_channel" "$normalized_architecture")"
 
     if [[ "$runtime" == "dotnet" ]]; then
         asset_relative_path="shared/Microsoft.NETCore.App"

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -116,7 +116,11 @@ export class DotnetCoreInstaller {
       }
 
       // process.env must be explicitly passed in for DOTNET_INSTALL_DIR to be used
-      const powershellPath = await io.which('powershell', true);
+      let powershellPath = await io.which('pwsh', false);
+      if (powershellPath == '')
+      {
+        powershellPath = await io.which('powershell', true);
+      }
 
       var options: ExecOptions = {
         listeners: {

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -116,7 +116,8 @@ export class DotnetCoreInstaller {
       }
 
       // process.env must be explicitly passed in for DOTNET_INSTALL_DIR to be used
-      const powershellPath = await io.which('pwsh', false) || await io.which('powershell', true);
+      const powershellPath =
+        (await io.which('pwsh', false)) || (await io.which('powershell', true));
 
       var options: ExecOptions = {
         listeners: {

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -116,10 +116,7 @@ export class DotnetCoreInstaller {
       }
 
       // process.env must be explicitly passed in for DOTNET_INSTALL_DIR to be used
-      let powershellPath = await io.which('pwsh', false);
-      if (powershellPath == '') {
-        powershellPath = await io.which('powershell', true);
-      }
+      const powershellPath = await io.which('pwsh', false) || await io.which('powershell', true);
 
       var options: ExecOptions = {
         listeners: {

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -117,8 +117,7 @@ export class DotnetCoreInstaller {
 
       // process.env must be explicitly passed in for DOTNET_INSTALL_DIR to be used
       let powershellPath = await io.which('pwsh', false);
-      if (powershellPath == '')
-      {
+      if (powershellPath == '') {
         powershellPath = await io.which('powershell', true);
       }
 


### PR DESCRIPTION
**Description:**
This PR fixes an issue where older versions of powershell (powershell versus pwsh (powershell core) is used on windows. Due to that, the `install-dotnet` script fails to detect it is on a windows arm device, and installs the x64 version of dotnet. 

So now we try to use powershell core if it exists, then fallback to powershell. This should not impact linux/mac os in any way.

**Related issue:**
Add link to the related issue.

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.