### PR TITLE
Add ability to write resolved version of SDK into the output variable

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -237,6 +237,60 @@ jobs:
             $version = & dotnet --version
             Write-Host "Installed version: $version"
             if (-not ($version.Contains("preview") -or $version.Contains("rc"))) { throw "Unexpected version" }
+  
+  test-dotnet-version-output-during-single-version-installation:
+      runs-on: ${{ matrix.operating-system }}
+      strategy:
+        fail-fast: false
+        matrix:
+          operating-system: [ubuntu-latest, windows-latest, macOS-latest]
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v3
+        - name: Clear toolcache
+          shell: pwsh
+          run: __tests__/clear-toolcache.ps1 ${{ runner.os }}
+               
+        - name: Setup dotnet 6.0.401
+          uses: ./
+          id: step1
+          with:
+            dotnet-version: "6.0.401"
+
+        - name: Verify value of the dotnet-version output
+          shell: pwsh
+          run: |
+            $version = & dotnet --version
+            Write-Host "Installed version: $version"
+            if (-not ($version -eq '${{steps.step1.outputs.dotnet-version}}')) { throw "Unexpected output value" }
+  
+  test-dotnet-version-output-during-multiple-version-installation:
+      runs-on: ${{ matrix.operating-system }}
+      strategy:
+        fail-fast: false
+        matrix:
+          operating-system: [ubuntu-latest, windows-latest, macOS-latest]
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v3
+        - name: Clear toolcache
+          shell: pwsh
+          run: __tests__/clear-toolcache.ps1 ${{ runner.os }}
+               
+        - name: Setup dotnet 6.0.401, 5.0.408, 7.0.100-rc.1.22431.12
+          uses: ./
+          id: step2
+          with:
+            dotnet-version: |
+              7.0.100-rc.1.22431.12
+              6.0.401
+              5.0.408
+
+        - name: Verify value of the dotnet-version output
+          shell: pwsh
+          run: |
+            $version = "7.0.100-rc.1.22431.12"
+            if (-not ($version -eq '${{steps.step2.outputs.dotnet-version}}')) { throw "Unexpected output value" }
 
   test-proxy:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -141,6 +141,41 @@ steps:
 ```
 > **Note**: It's the only way to push a package to nuget.org feed for macOS/Linux machines due to API key config store limitations.
 
+# Outputs and environment variables
+
+## Outputs
+
+### `dotnet-version`
+
+Using **dotnet-version** output it's possible to get the installed by action .NET SDK version. 
+
+**Single version installation**
+
+In case of a single version installation, `dotnet-version` contains the version that is installed by the action.
+
+```yaml
+    - uses: actions/setup-dotnet@v3
+      id: cp310
+      with:
+        dotnet-version: 3.1.422
+    - run: echo '${{ steps.cp310.outputs.dotnet-version }}' # outputs 3.1.422
+```
+
+**Multiple version installation**
+
+In case of a multiple version installation, `dotnet-version` contains the latest version that is installed by the action.
+
+```yaml
+    - uses: actions/setup-dotnet@v3
+      id: cp310
+      with:
+        dotnet-version: | 
+          3.1.422
+          5.0.408
+    - run: echo '${{ steps.cp310.outputs.dotnet-version }}' # outputs 5.0.408
+```
+
+
 ## Environment variables
 
 Some environment variables may be necessary for your particular case or to improve logging. Some examples are listed below, but the full list with complete details can be found here: https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-environment-variables

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,9 @@ inputs:
     description: 'Optional OWNER for using packages from GitHub Package Registry organizations/users other than the current repository''s owner. Only used if a GPR URL is also provided in source-url'
   config-file:
     description: 'Optional NuGet.config location, if your NuGet.config isn''t located in the root of the repo.'
+outputs:
+  dotnet-version:
+    description: 'Contains the installed by action .NET SDK version for reuse.'
 runs:
   using: 'node16'
   main: 'dist/index.js'

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -238,5 +238,27 @@ export class DotnetCoreInstaller {
     if (exitCode) {
       throw new Error(`Failed to install dotnet ${exitCode}. ${stdout}`);
     }
+
+    return this.outputDotnetVersion(stdout);
+  }
+
+  private outputDotnetVersion(logs: string): string {
+    let resolvedVersion: string = '';
+    const installedByScriptPattern = /Installed version is (?<version>\d+\.\d+\.\d.*)$/m;
+    const preinstalledOnRunnerPattern = /.NET Core SDK with version '(?<version>\d+\.\d+\.\d.*)'/m;
+
+    let regExpressions: RegExp[] = [
+      installedByScriptPattern,
+      preinstalledOnRunnerPattern
+    ];
+
+    for (let regExp of regExpressions) {
+      if (regExp.test(logs)) {
+        resolvedVersion = logs.match(regExp)!.groups!.version;
+        break;
+      }
+    }
+
+    return resolvedVersion;
   }
 }


### PR DESCRIPTION
**Description:**
In the scope of this PR, the ability to write resolved version of SDK into the output variable `dotnet-version` was added. In the case of multiline input, the latest resolved version (include prerelease ones) will be returned.

**Related issue:**
https://github.com/actions/setup-dotnet/issues/241
**Check list:**
- [x] Mark if documentation changes are required.
- [x] Mark if tests were added or updated to cover the changes.