### PR TITLE
Enable ability to change .NET SDK installation directory by `DOTNET_INSTALL_DIR` environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Some environment variables may be necessary for your particular case or to impro
 build:
   runs-on: ubuntu-latest
   env:
-    DOTNET_INSTALL_DIR: "some/directory"
+    DOTNET_INSTALL_DIR: "some/specific/directory"
   steps:
     - uses: actions/checkout@main
     - uses: actions/setup-dotnet@v3

--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ Some environment variables may be necessary for your particular case or to impro
 
 | **Env.variable**      | **Description** | **Default value** |
 | ----------- | ----------- | ----------- |
+| DOTNET_INSTALL_DIR      |Specifies a directory where .NET SDKs should be installed by the action|*isn't set*|
 | DOTNET_NOLOGO      |Removes logo and telemetry message from first run of dotnet cli|*false*|
 | DOTNET_CLI_TELEMETRY_OPTOUT   |Opt-out of telemetry being sent to Microsoft|*false*|
 | DOTNET_MULTILEVEL_LOOKUP   |Configures whether the global install location is used as a fall-back|*true*|
@@ -204,7 +205,7 @@ Some environment variables may be necessary for your particular case or to impro
 build:
   runs-on: ubuntu-latest
   env:
-    DOTNET_NOLOGO: true
+    DOTNET_INSTALL_DIR: "some/directory"
   steps:
     - uses: actions/checkout@main
     - uses: actions/setup-dotnet@v3

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Some environment variables may be necessary for your particular case or to impro
 build:
   runs-on: ubuntu-latest
   env:
-    DOTNET_INSTALL_DIR: "some/specific/directory"
+    DOTNET_INSTALL_DIR: "path/to/directory"
   steps:
     - uses: actions/checkout@main
     - uses: actions/setup-dotnet@v3

--- a/dist/index.js
+++ b/dist/index.js
@@ -337,7 +337,7 @@ class DotnetCoreInstaller {
                 if (process.env['no_proxy'] != null) {
                     scriptArguments.push(`-ProxyBypassList ${process.env['no_proxy']}`);
                 }
-                if (!process.env['DOTNET_INSTALL_DIR']) {
+                if (!dotnetInstallDir) {
                     scriptArguments.push('-InstallDir', `'${DotnetCoreInstaller.installationDirectoryWindows}'`);
                 }
                 // process.env must be explicitly passed in for DOTNET_INSTALL_DIR to be used
@@ -355,7 +355,7 @@ class DotnetCoreInstaller {
                 if (this.quality) {
                     this.setQuality(dotnetVersion, scriptArguments);
                 }
-                if (!process.env['DOTNET_INSTALL_DIR']) {
+                if (!dotnetInstallDir) {
                     scriptArguments.push('--install-dir', utils_1.IS_LINUX
                         ? DotnetCoreInstaller.installationDirectoryLinux
                         : DotnetCoreInstaller.installationDirectoryMac);
@@ -365,8 +365,8 @@ class DotnetCoreInstaller {
             if (exitCode) {
                 throw new Error(`Failed to install dotnet ${exitCode}. ${stdout}`);
             }
-            return this.outputDotnetVersion(dotnetVersion.value, process.env['DOTNET_INSTALL_DIR']
-                ? process.env['DOTNET_INSTALL_DIR']
+            return this.outputDotnetVersion(dotnetVersion.value, dotnetInstallDir
+                ? dotnetInstallDir
                 : scriptArguments[scriptArguments.length - 1]);
         });
     }

--- a/dist/index.js
+++ b/dist/index.js
@@ -361,7 +361,11 @@ class DotnetCoreInstaller {
                         : DotnetCoreInstaller.installationDirectoryMac);
                 }
             }
-            const { exitCode, stdout } = yield exec.getExecOutput(`"${scriptPath}"`, scriptArguments, { ignoreReturnCode: true });
+            const getExecOutputOptions = {
+                ignoreReturnCode: true,
+                env: process.env
+            };
+            const { exitCode, stdout } = yield exec.getExecOutput(`"${scriptPath}"`, scriptArguments, getExecOutputOptions);
             if (exitCode) {
                 throw new Error(`Failed to install dotnet ${exitCode}. ${stdout}`);
             }

--- a/dist/index.js
+++ b/dist/index.js
@@ -301,6 +301,10 @@ class DotnetCoreInstaller {
     }
     installDotnet() {
         return __awaiter(this, void 0, void 0, function* () {
+            const dotnetInstallDir = process.env['DOTNET_INSTALL_DIR'];
+            if (dotnetInstallDir) {
+                core.debug(`DOTNET_INSTALL_DIR is set up to ${dotnetInstallDir}`);
+            }
             const windowsDefaultOptions = [
                 '-NoLogo',
                 '-Sta',

--- a/dist/index.js
+++ b/dist/index.js
@@ -301,10 +301,6 @@ class DotnetCoreInstaller {
     }
     installDotnet() {
         return __awaiter(this, void 0, void 0, function* () {
-            const dotnetInstallDir = process.env['DOTNET_INSTALL_DIR'];
-            if (dotnetInstallDir) {
-                core.debug(`DOTNET_INSTALL_DIR is set up to ${dotnetInstallDir}`);
-            }
             const windowsDefaultOptions = [
                 '-NoLogo',
                 '-Sta',
@@ -337,10 +333,10 @@ class DotnetCoreInstaller {
                 if (process.env['no_proxy'] != null) {
                     scriptArguments.push(`-ProxyBypassList ${process.env['no_proxy']}`);
                 }
-                if (!dotnetInstallDir) {
-                    scriptArguments.push('-InstallDir', `'${DotnetCoreInstaller.installationDirectoryWindows}'`);
+                if (!process.env['DOTNET_INSTALL_DIR']) {
+                    process.env['DOTNET_INSTALL_DIR'] =
+                        DotnetCoreInstaller.installationDirectoryWindows;
                 }
-                // process.env must be explicitly passed in for DOTNET_INSTALL_DIR to be used
                 scriptPath =
                     (yield io.which('pwsh', false)) || (yield io.which('powershell', true));
                 scriptArguments = windowsDefaultOptions.concat(scriptArguments);
@@ -355,12 +351,13 @@ class DotnetCoreInstaller {
                 if (this.quality) {
                     this.setQuality(dotnetVersion, scriptArguments);
                 }
-                if (!dotnetInstallDir) {
-                    scriptArguments.push('--install-dir', utils_1.IS_LINUX
+                if (!process.env['DOTNET_INSTALL_DIR']) {
+                    process.env['DOTNET_INSTALL_DIR'] = utils_1.IS_LINUX
                         ? DotnetCoreInstaller.installationDirectoryLinux
-                        : DotnetCoreInstaller.installationDirectoryMac);
+                        : DotnetCoreInstaller.installationDirectoryMac;
                 }
             }
+            // process.env must be explicitly passed in for DOTNET_INSTALL_DIR to be used
             const getExecOutputOptions = {
                 ignoreReturnCode: true,
                 env: process.env
@@ -369,9 +366,7 @@ class DotnetCoreInstaller {
             if (exitCode) {
                 throw new Error(`Failed to install dotnet ${exitCode}. ${stdout}`);
             }
-            return this.outputDotnetVersion(dotnetVersion.value, dotnetInstallDir
-                ? dotnetInstallDir
-                : scriptArguments[scriptArguments.length - 1]);
+            return this.outputDotnetVersion(dotnetVersion.value, process.env['DOTNET_INSTALL_DIR']);
         });
     }
     outputDotnetVersion(version, installationPath) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -333,7 +333,9 @@ class DotnetCoreInstaller {
                 if (process.env['no_proxy'] != null) {
                     scriptArguments.push(`-ProxyBypassList ${process.env['no_proxy']}`);
                 }
-                scriptArguments.push('-InstallDir', `'${DotnetCoreInstaller.installationDirectoryWindows}'`);
+                if (!process.env['DOTNET_INSTALL_DIR']) {
+                    scriptArguments.push('-InstallDir', `'${DotnetCoreInstaller.installationDirectoryWindows}'`);
+                }
                 // process.env must be explicitly passed in for DOTNET_INSTALL_DIR to be used
                 scriptPath =
                     (yield io.which('pwsh', false)) || (yield io.which('powershell', true));
@@ -349,18 +351,19 @@ class DotnetCoreInstaller {
                 if (this.quality) {
                     this.setQuality(dotnetVersion, scriptArguments);
                 }
-                if (utils_1.IS_LINUX) {
-                    scriptArguments.push('--install-dir', DotnetCoreInstaller.installationDirectoryLinux);
-                }
-                if (utils_1.IS_MAC) {
-                    scriptArguments.push('--install-dir', DotnetCoreInstaller.installationDirectoryMac);
+                if (!process.env['DOTNET_INSTALL_DIR']) {
+                    scriptArguments.push('--install-dir', utils_1.IS_LINUX
+                        ? DotnetCoreInstaller.installationDirectoryLinux
+                        : DotnetCoreInstaller.installationDirectoryMac);
                 }
             }
             const { exitCode, stdout } = yield exec.getExecOutput(`"${scriptPath}"`, scriptArguments, { ignoreReturnCode: true });
             if (exitCode) {
                 throw new Error(`Failed to install dotnet ${exitCode}. ${stdout}`);
             }
-            return this.outputDotnetVersion(dotnetVersion.value, scriptArguments[scriptArguments.length - 1]);
+            return this.outputDotnetVersion(dotnetVersion.value, process.env['DOTNET_INSTALL_DIR']
+                ? process.env['DOTNET_INSTALL_DIR']
+                : scriptArguments[scriptArguments.length - 1]);
         });
     }
     outputDotnetVersion(version, installationPath) {
@@ -523,10 +526,9 @@ run();
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.IS_MAC = exports.IS_LINUX = exports.IS_WINDOWS = void 0;
+exports.IS_LINUX = exports.IS_WINDOWS = void 0;
 exports.IS_WINDOWS = process.platform === 'win32';
 exports.IS_LINUX = process.platform === 'linux';
-exports.IS_MAC = process.platform === 'darwin';
 
 
 /***/ }),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "setup-dotnet",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "setup-dotnet",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.9.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-dotnet",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "private": true,
   "description": "setup dotnet action",
   "main": "lib/setup-dotnet.js",

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -170,6 +170,10 @@ export class DotnetCoreInstaller {
   }
 
   public async installDotnet(): Promise<string> {
+    const dotnetInstallDir = process.env['DOTNET_INSTALL_DIR'];
+    if (dotnetInstallDir) {
+      core.debug(`DOTNET_INSTALL_DIR is set up to ${dotnetInstallDir}`);
+    }
     const windowsDefaultOptions = [
       '-NoLogo',
       '-Sta',

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -244,10 +244,15 @@ export class DotnetCoreInstaller {
         );
       }
     }
+
+    const getExecOutputOptions = {
+      ignoreReturnCode: true,
+      env: process.env as {string: string}
+    };
     const {exitCode, stdout} = await exec.getExecOutput(
       `"${scriptPath}"`,
       scriptArguments,
-      {ignoreReturnCode: true}
+      getExecOutputOptions
     );
     if (exitCode) {
       throw new Error(`Failed to install dotnet ${exitCode}. ${stdout}`);

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -170,10 +170,6 @@ export class DotnetCoreInstaller {
   }
 
   public async installDotnet(): Promise<string> {
-    const dotnetInstallDir = process.env['DOTNET_INSTALL_DIR'];
-    if (dotnetInstallDir) {
-      core.debug(`DOTNET_INSTALL_DIR is set up to ${dotnetInstallDir}`);
-    }
     const windowsDefaultOptions = [
       '-NoLogo',
       '-Sta',
@@ -212,13 +208,11 @@ export class DotnetCoreInstaller {
         scriptArguments.push(`-ProxyBypassList ${process.env['no_proxy']}`);
       }
 
-      if (!dotnetInstallDir) {
-        scriptArguments.push(
-          '-InstallDir',
-          `'${DotnetCoreInstaller.installationDirectoryWindows}'`
-        );
+      if (!process.env['DOTNET_INSTALL_DIR']) {
+        process.env['DOTNET_INSTALL_DIR'] =
+          DotnetCoreInstaller.installationDirectoryWindows;
       }
-      // process.env must be explicitly passed in for DOTNET_INSTALL_DIR to be used
+
       scriptPath =
         (await io.which('pwsh', false)) || (await io.which('powershell', true));
       scriptArguments = windowsDefaultOptions.concat(scriptArguments);
@@ -235,16 +229,13 @@ export class DotnetCoreInstaller {
         this.setQuality(dotnetVersion, scriptArguments);
       }
 
-      if (!dotnetInstallDir) {
-        scriptArguments.push(
-          '--install-dir',
-          IS_LINUX
-            ? DotnetCoreInstaller.installationDirectoryLinux
-            : DotnetCoreInstaller.installationDirectoryMac
-        );
+      if (!process.env['DOTNET_INSTALL_DIR']) {
+        process.env['DOTNET_INSTALL_DIR'] = IS_LINUX
+          ? DotnetCoreInstaller.installationDirectoryLinux
+          : DotnetCoreInstaller.installationDirectoryMac;
       }
     }
-
+    // process.env must be explicitly passed in for DOTNET_INSTALL_DIR to be used
     const getExecOutputOptions = {
       ignoreReturnCode: true,
       env: process.env as {string: string}
@@ -260,9 +251,7 @@ export class DotnetCoreInstaller {
 
     return this.outputDotnetVersion(
       dotnetVersion.value,
-      dotnetInstallDir
-        ? dotnetInstallDir
-        : scriptArguments[scriptArguments.length - 1]
+      process.env['DOTNET_INSTALL_DIR']
     );
   }
 

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -212,7 +212,7 @@ export class DotnetCoreInstaller {
         scriptArguments.push(`-ProxyBypassList ${process.env['no_proxy']}`);
       }
 
-      if (!process.env['DOTNET_INSTALL_DIR']) {
+      if (!dotnetInstallDir) {
         scriptArguments.push(
           '-InstallDir',
           `'${DotnetCoreInstaller.installationDirectoryWindows}'`
@@ -235,7 +235,7 @@ export class DotnetCoreInstaller {
         this.setQuality(dotnetVersion, scriptArguments);
       }
 
-      if (!process.env['DOTNET_INSTALL_DIR']) {
+      if (!dotnetInstallDir) {
         scriptArguments.push(
           '--install-dir',
           IS_LINUX
@@ -255,8 +255,8 @@ export class DotnetCoreInstaller {
 
     return this.outputDotnetVersion(
       dotnetVersion.value,
-      process.env['DOTNET_INSTALL_DIR']
-        ? process.env['DOTNET_INSTALL_DIR']
+      dotnetInstallDir
+        ? dotnetInstallDir
         : scriptArguments[scriptArguments.length - 1]
     );
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,2 @@
 export const IS_WINDOWS = process.platform === 'win32';
 export const IS_LINUX = process.platform === 'linux';
-export const IS_MAC = process.platform === 'darwin';


### PR DESCRIPTION
**Description:**
In scope of this PR the `DOTNET_INSTALL_DIR` environment variable was enabled to add the ability to change the installation directory for .NET SDK. The `DOTNET_INSTALL_DIR` can be helpful when access to the default installation directory, for instance, on self-hosted runners, is denied. Also, the `DOTNET_INSTALL_DIR` environment variable was documented.

**Related issue:**
[Issue](https://github.com/actions/setup-dotnet/issues/327)

**Check list:**
- [x] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.