### PR TITLE
Make throwing errors in setup-dotnet more informative

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -398,9 +398,9 @@ class DotnetCoreInstaller {
                 ignoreReturnCode: true,
                 env: process.env
             };
-            const { exitCode, stdout } = yield exec.getExecOutput(`"${scriptPath}"`, scriptArguments, getExecOutputOptions);
+            const { exitCode, stderr } = yield exec.getExecOutput(`"${scriptPath}"`, scriptArguments, getExecOutputOptions);
             if (exitCode) {
-                throw new Error(`Failed to install dotnet ${exitCode}. ${stdout}`);
+                throw new Error(`Failed to install dotnet, exit code: ${exitCode}. ${stderr}`);
             }
             return this.outputDotnetVersion(dotnetVersion.value);
         });

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -236,13 +236,15 @@ export class DotnetCoreInstaller {
       ignoreReturnCode: true,
       env: process.env as {string: string}
     };
-    const {exitCode, stdout} = await exec.getExecOutput(
+    const {exitCode, stderr} = await exec.getExecOutput(
       `"${scriptPath}"`,
       scriptArguments,
       getExecOutputOptions
     );
     if (exitCode) {
-      throw new Error(`Failed to install dotnet ${exitCode}. ${stdout}`);
+      throw new Error(
+        `Failed to install dotnet, exit code: ${exitCode}. ${stderr}`
+      );
     }
 
     return this.outputDotnetVersion(dotnetVersion.value);


### PR DESCRIPTION
**Description:**
During the installation of .NET using the setup-dotnet action some errors may be thrown. Usually, an error message should contain a comprehensive reason for the error, but in the setup-dotnet, there is a case where it's not like that. [These](https://github.com/actions/setup-dotnet/blob/main/src/installer.ts#L239-L246) lines of code contain a small bug that should be fixed.

**Related issue:**
[Link](https://github.com/actions/runner-images-internal/issues/4785)

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.