### PR TITLE
Update workflow badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # setup-dotnet
 
-[![GitHub Actions Status](https://github.com/actions/setup-dotnet/workflows/Main%20workflow/badge.svg)](https://github.com/actions/setup-dotnet)
+[![Basic validation](https://github.com/actions/setup-dotnet/actions/workflows/basic-validation.yml/badge.svg?branch=main)](https://github.com/actions/setup-dotnet/actions/workflows/basic-validation.yml)
+[![e2e tests](https://github.com/actions/setup-dotnet/actions/workflows/e2e-tests.yml/badge.svg?branch=main)](https://github.com/actions/setup-dotnet/actions/workflows/e2e-tests.yml)
 
 This action sets up a [.NET CLI](https://github.com/dotnet/sdk) environment for use in actions by:
 


### PR DESCRIPTION
**Description:**
In the scope of this PR, [workflow badges](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/adding-a-workflow-status-badge) were updated to represent the current status of the workflows which test the action. The badges were organized like that:
1. Badge for a workflow with unit tests
2. Badges for other workflows with several e2e tests

Use `display the rich diff` button to see the visual representation of the changes:
![image](https://user-images.githubusercontent.com/98037481/215442456-56bd363d-897b-4111-bd37-1dcdfcb2bbc0.png)

**Related issue:**
https://github.com/actions/runner-images-internal/issues/4709