### PR TITLE
Accept absolute paths for 'global-json-file' input

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -513,7 +513,7 @@ function run() {
             const installedDotnetVersions = [];
             const globalJsonFileInput = core.getInput('global-json-file');
             if (globalJsonFileInput) {
-                const globalJsonPath = path_1.default.join(process.cwd(), globalJsonFileInput);
+                const globalJsonPath = path_1.default.resolve(process.cwd(), globalJsonFileInput);
                 if (!fs.existsSync(globalJsonPath)) {
                     throw new Error(`The specified global.json file '${globalJsonFileInput}' does not exist`);
                 }

--- a/src/setup-dotnet.ts
+++ b/src/setup-dotnet.ts
@@ -31,7 +31,7 @@ export async function run() {
 
     const globalJsonFileInput = core.getInput('global-json-file');
     if (globalJsonFileInput) {
-      const globalJsonPath = path.join(process.cwd(), globalJsonFileInput);
+      const globalJsonPath = path.resolve(process.cwd(), globalJsonFileInput);
       if (!fs.existsSync(globalJsonPath)) {
         throw new Error(
           `The specified global.json file '${globalJsonFileInput}' does not exist`


### PR DESCRIPTION
**Description:**
Use `path.resolve` instead of `path.join` to handle absolute paths correctly

**Related issue:**
fixes #378

**Check list:**
- [ ] Mark if documentation changes are required.
- [x] Mark if tests were added or updated to cover the changes.