### PR TITLE
Fix glob bug in package.json scripts section

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
   "main": "lib/setup-dotnet.js",
   "scripts": {
     "build": "tsc && ncc build",
-    "format": "prettier --no-error-on-unmatched-pattern --config ./.prettierrc.js --write **/*.{ts,yml,yaml}",
-    "format-check": "prettier --no-error-on-unmatched-pattern --config ./.prettierrc.js --check **/*.{ts,yml,yaml}",
-    "lint": "eslint --config ./.eslintrc.js **/*.ts",
-    "lint:fix": "eslint --config ./.eslintrc.js **/*.ts --fix",
+    "format": "prettier --no-error-on-unmatched-pattern --config ./.prettierrc.js --write \"**/*.{ts,yml,yaml}\"",
+    "format-check": "prettier --no-error-on-unmatched-pattern --config ./.prettierrc.js --check \"**/*.{ts,yml,yaml}\"",
+    "lint": "eslint --config ./.eslintrc.js \"**/*.ts\"",
+    "lint:fix": "eslint --config ./.eslintrc.js \"**/*.ts\" --fix",
     "prepare": "husky install",
     "test": "jest --coverage --config ./jest.config.js",
     "update-installers": "nwget https://dot.net/v1/dotnet-install.ps1 -O externals/install-dotnet.ps1 && nwget https://dot.net/v1/dotnet-install.sh -O externals/install-dotnet.sh"


### PR DESCRIPTION
**Description:**
In the scope of this PR, we fix the bug related to the wrong interpretation of the glob patterns. Glob patterns that aren't wrapped by the quotes are opened and transformed into concrete paths by the shell used in the OS (e.g., PowerShell, bash. zsh, and so on). The behavior of this transformation is different for different shells, which can cause different behaviors of the tools. By wrapping glob patterns in double quotes, we prevent shell from opening and transforming them and instruct tool to do it instead.

**Related issue:**
https://github.com/actions/runner-images-internal/issues/4899