### PR TITLE
Increase amount of retries for Dotnet installation scripts tests

### DIFF
--- a/__tests__/installation-scripts.test.ts
+++ b/__tests__/installation-scripts.test.ts
@@ -2,43 +2,59 @@ import path from 'path';
 import fs from 'fs';
 import * as hc from '@actions/http-client';
 
-const HTTP_CLIENT_OPTIONS = { allowRetries: true, maxRetries: 10 } as const;
+const HTTP_CLIENT_OPTIONS = {allowRetries: true, maxRetries: 10} as const;
 const TEST_TIMEOUT = 30000;
 
 describe('Dotnet installation scripts tests', () => {
-  it('Uses an up to date bash download script', async () => {
-    const httpCallbackClient = new hc.HttpClient('setup-dotnet-test', [], HTTP_CLIENT_OPTIONS);
-    const response: hc.HttpClientResponse = await httpCallbackClient.get(
-      'https://dot.net/v1/dotnet-install.sh'
-    );
-    expect(response.message.statusCode).toBe(200);
-    const upToDateContents: string = await response.readBody();
-    const currentContents: string = fs
-      .readFileSync(
-        path.join(__dirname, '..', 'externals', 'install-dotnet.sh')
-      )
-      .toString();
-    expect(normalizeFileContents(currentContents)).toBe(
-      normalizeFileContents(upToDateContents)
-    );
-  }, TEST_TIMEOUT);
+  it(
+    'Uses an up to date bash download script',
+    async () => {
+      const httpCallbackClient = new hc.HttpClient(
+        'setup-dotnet-test',
+        [],
+        HTTP_CLIENT_OPTIONS
+      );
+      const response: hc.HttpClientResponse = await httpCallbackClient.get(
+        'https://dot.net/v1/dotnet-install.sh'
+      );
+      expect(response.message.statusCode).toBe(200);
+      const upToDateContents: string = await response.readBody();
+      const currentContents: string = fs
+        .readFileSync(
+          path.join(__dirname, '..', 'externals', 'install-dotnet.sh')
+        )
+        .toString();
+      expect(normalizeFileContents(currentContents)).toBe(
+        normalizeFileContents(upToDateContents)
+      );
+    },
+    TEST_TIMEOUT
+  );
 
-  it('Uses an up to date powershell download script', async () => {
-    const httpCallbackClient = new hc.HttpClient('setup-dotnet-test', [], HTTP_CLIENT_OPTIONS);
-    const response: hc.HttpClientResponse = await httpCallbackClient.get(
-      'https://dot.net/v1/dotnet-install.ps1'
-    );
-    expect(response.message.statusCode).toBe(200);
-    const upToDateContents: string = await response.readBody();
-    const currentContents: string = fs
-      .readFileSync(
-        path.join(__dirname, '..', 'externals', 'install-dotnet.ps1')
-      )
-      .toString();
-    expect(normalizeFileContents(currentContents)).toBe(
-      normalizeFileContents(upToDateContents)
-    );
-  }, TEST_TIMEOUT);
+  it(
+    'Uses an up to date powershell download script',
+    async () => {
+      const httpCallbackClient = new hc.HttpClient(
+        'setup-dotnet-test',
+        [],
+        HTTP_CLIENT_OPTIONS
+      );
+      const response: hc.HttpClientResponse = await httpCallbackClient.get(
+        'https://dot.net/v1/dotnet-install.ps1'
+      );
+      expect(response.message.statusCode).toBe(200);
+      const upToDateContents: string = await response.readBody();
+      const currentContents: string = fs
+        .readFileSync(
+          path.join(__dirname, '..', 'externals', 'install-dotnet.ps1')
+        )
+        .toString();
+      expect(normalizeFileContents(currentContents)).toBe(
+        normalizeFileContents(upToDateContents)
+      );
+    },
+    TEST_TIMEOUT
+  );
 });
 
 function normalizeFileContents(contents: string): string {

--- a/__tests__/installation-scripts.test.ts
+++ b/__tests__/installation-scripts.test.ts
@@ -2,12 +2,12 @@ import path from 'path';
 import fs from 'fs';
 import * as hc from '@actions/http-client';
 
+const HTTP_CLIENT_OPTIONS = { allowRetries: true, maxRetries: 10 } as const;
+const TEST_TIMEOUT = 30000;
+
 describe('Dotnet installation scripts tests', () => {
   it('Uses an up to date bash download script', async () => {
-    const httpCallbackClient = new hc.HttpClient('setup-dotnet-test', [], {
-      allowRetries: true,
-      maxRetries: 3
-    });
+    const httpCallbackClient = new hc.HttpClient('setup-dotnet-test', [], HTTP_CLIENT_OPTIONS);
     const response: hc.HttpClientResponse = await httpCallbackClient.get(
       'https://dot.net/v1/dotnet-install.sh'
     );
@@ -21,13 +21,10 @@ describe('Dotnet installation scripts tests', () => {
     expect(normalizeFileContents(currentContents)).toBe(
       normalizeFileContents(upToDateContents)
     );
-  }, 30000);
+  }, TEST_TIMEOUT);
 
   it('Uses an up to date powershell download script', async () => {
-    const httpCallbackClient = new hc.HttpClient('setup-dotnet-test', [], {
-      allowRetries: true,
-      maxRetries: 3
-    });
+    const httpCallbackClient = new hc.HttpClient('setup-dotnet-test', [], HTTP_CLIENT_OPTIONS);
     const response: hc.HttpClientResponse = await httpCallbackClient.get(
       'https://dot.net/v1/dotnet-install.ps1'
     );
@@ -41,7 +38,7 @@ describe('Dotnet installation scripts tests', () => {
     expect(normalizeFileContents(currentContents)).toBe(
       normalizeFileContents(upToDateContents)
     );
-  }, 30000);
+  }, TEST_TIMEOUT);
 });
 
 function normalizeFileContents(contents: string): string {


### PR DESCRIPTION
**Description:**
Increased amount of retries for tests that require fetching dotnet-install scripts as they tend to fail from time to time. 

**Related issue:**
—

**Check list:**
- [ ] Mark if documentation changes are required.
- [x] Mark if tests were added or updated to cover the changes.