### PR TITLE
Sequential version install fix

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -433,8 +433,8 @@ jobs:
       fail-fast: false
       matrix:
         operating-system: [ubuntu-latest, windows-latest, macOS-latest]
-        lower-version: ['2.2.402', '3.0.103', '3.1.426', '6.0.408', '7.0.100']
-        higher-version: ['6.0.408', '7.0.203']
+        lower-version: ['3.1.426']
+        higher-version: ['7.0.203']
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -455,4 +455,4 @@ jobs:
           dotnet-version: ${{ matrix.higher-version }}
       - name: Verify dotnet (higher version)
         shell: pwsh
-        run: __tests__/verify-dotnet.ps1 -Patterns "^${{ matrix.higher-version }}$"
+        run: __tests__/verify-dotnet.ps1 -Patterns "^${{ matrix.lower-version }}$", "^${{ matrix.higher-version }}$"

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -433,6 +433,8 @@ jobs:
       fail-fast: false
       matrix:
         operating-system: [ubuntu-latest, windows-latest, macOS-latest]
+        lower-version: ['2.2.402', '3.0.103', '3.1.426', '6.0.408', '7.0.100']
+        higher-version: ['6.0.408', '7.0.203']
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -440,17 +442,17 @@ jobs:
         shell: pwsh
         run: __tests__/clear-toolcache.ps1 ${{ runner.os }}
       # Install one version, use it for something, then switch to next version
-      - name: Setup dotnet 2.2.402
+      - name: Setup dotnet (lower version)
         uses: ./
         with:
-          dotnet-version: 2.2.402
-      - name: Verify dotnet 2.2.402
+          dotnet-version: ${{ matrix.lower-version }}
+      - name: Verify dotnet (lower version)
         shell: pwsh
-        run: __tests__/verify-dotnet.ps1 -Patterns "^2.2.402$"
-      - name: Setup dotnet 7.0.203
+        run: __tests__/verify-dotnet.ps1 -Patterns "^${{ matrix.lower-version }}$"
+      - name: Setup dotnet (higher version)
         uses: ./
         with:
-          dotnet-version: 7.0.203
-      - name: Verify dotnet 7.0.203
+          dotnet-version: ${{ matrix.higher-version }}
+      - name: Verify dotnet (higher version)
         shell: pwsh
-        run: __tests__/verify-dotnet.ps1 -Patterns "^7.0.203$"
+        run: __tests__/verify-dotnet.ps1 -Patterns "^${{ matrix.higher-version }}$"

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -426,3 +426,31 @@ jobs:
       - name: Verify dotnet
         shell: pwsh
         run: __tests__/verify-dotnet.ps1 -Patterns "^3.1.201$" -CheckNugetConfig
+
+  test-sequential-version-installation:
+    runs-on: ${{ matrix.operating-system }}
+    strategy:
+      fail-fast: false
+      matrix:
+        operating-system: [ubuntu-latest, windows-latest, macOS-latest]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Clear toolcache
+        shell: pwsh
+        run: __tests__/clear-toolcache.ps1 ${{ runner.os }}
+      # Install one version, use it for something, then switch to next version
+      - name: Setup dotnet 2.2.402
+        uses: ./
+        with:
+          dotnet-version: 2.2.402
+      - name: Verify dotnet 2.2.402
+        shell: pwsh
+        run: __tests__/verify-dotnet.ps1 -Patterns "^2.2.402$"
+      - name: Setup dotnet 7.0.203
+        uses: ./
+        with:
+          dotnet-version: 7.0.203
+      - name: Verify dotnet 7.0.203
+        shell: pwsh
+        run: __tests__/verify-dotnet.ps1 -Patterns "^7.0.203$"

--- a/__tests__/installer.test.ts
+++ b/__tests__/installer.test.ts
@@ -102,8 +102,15 @@ describe('installer tests', () => {
 
         await dotnetInstaller.installDotnet();
 
+        /**
+         * First time script would be called to
+         * install runtime, here we checking only the
+         * second one that installs actual SDK. i.e. 1
+         */
+        const callIndex = 1;
+
         const scriptArguments = (
-          getExecOutputSpy.mock.calls[0][1] as string[]
+          getExecOutputSpy.mock.calls[callIndex][1] as string[]
         ).join(' ');
         const expectedArgument = IS_WINDOWS
           ? `-Version ${inputVersion}`
@@ -185,8 +192,15 @@ describe('installer tests', () => {
 
           await dotnetInstaller.installDotnet();
 
+          /**
+           * First time script would be called to
+           * install runtime, here we checking only the
+           * second one that installs actual SDK. i.e. 1
+           */
+          const callIndex = 1;
+
           const scriptArguments = (
-            getExecOutputSpy.mock.calls[0][1] as string[]
+            getExecOutputSpy.mock.calls[callIndex][1] as string[]
           ).join(' ');
           const expectedArgument = IS_WINDOWS
             ? `-Quality ${inputQuality}`
@@ -218,8 +232,15 @@ describe('installer tests', () => {
 
           await dotnetInstaller.installDotnet();
 
+          /**
+           * First time script would be called to
+           * install runtime, here we checking only the
+           * second one that installs actual SDK. i.e. 1
+           */
+          const callIndex = 1;
+
           const scriptArguments = (
-            getExecOutputSpy.mock.calls[0][1] as string[]
+            getExecOutputSpy.mock.calls[callIndex][1] as string[]
           ).join(' ');
           const expectedArgument = IS_WINDOWS
             ? `-Channel 6.0`
@@ -252,8 +273,15 @@ describe('installer tests', () => {
 
           await dotnetInstaller.installDotnet();
 
+          /**
+           * First time script would be called to
+           * install runtime, here we checking only the
+           * second one that installs actual SDK. i.e. 1
+           */
+          const callIndex = 1;
+
           const scriptArguments = (
-            getExecOutputSpy.mock.calls[0][1] as string[]
+            getExecOutputSpy.mock.calls[callIndex][1] as string[]
           ).join(' ');
 
           expect(scriptArguments).toContain(
@@ -283,8 +311,15 @@ describe('installer tests', () => {
 
           await dotnetInstaller.installDotnet();
 
+          /**
+           * First time script would be called to
+           * install runtime, here we checking only the
+           * second one that installs actual SDK. i.e. 1
+           */
+          const callIndex = 1;
+
           const scriptArguments = (
-            getExecOutputSpy.mock.calls[0][1] as string[]
+            getExecOutputSpy.mock.calls[callIndex][1] as string[]
           ).join(' ');
 
           expect(scriptArguments).toContain(

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -71385,14 +71385,39 @@ class DotnetCoreInstaller {
         return __awaiter(this, void 0, void 0, function* () {
             const versionResolver = new DotnetVersionResolver(this.version);
             const dotnetVersion = yield versionResolver.createDotnetVersion();
-            const installScript = new DotnetInstallScript()
+            /**
+             * Install dotnet runitme first in order to get
+             * the latest stable version of dotnet CLI
+             */
+            const runtimeInstallOutput = yield new DotnetInstallScript()
+                // If dotnet CLI is already installed - avoid overwriting it
                 .useArguments(utils_1.IS_WINDOWS ? '-SkipNonVersionedFiles' : '--skip-non-versioned-files')
-                .useVersion(dotnetVersion, this.quality);
-            const { exitCode, stderr, stdout } = yield installScript.execute();
-            if (exitCode) {
-                throw new Error(`Failed to install dotnet, exit code: ${exitCode}. ${stderr}`);
+                // Install only runtime + CLI
+                .useArguments(utils_1.IS_WINDOWS ? '-Runtime' : '--runtime', 'dotnet')
+                // Use latest stable version
+                .useArguments(utils_1.IS_WINDOWS ? '-Channel' : '--channel', 'LTS')
+                .execute();
+            if (runtimeInstallOutput.exitCode) {
+                /**
+                 * dotnetInstallScript will install CLI and runtime even if previous script haven't succeded,
+                 * so at this point it's too early to throw an error
+                 */
+                core.warning(`Failed to install dotnet runtime + cli, exit code: ${runtimeInstallOutput.exitCode}. ${runtimeInstallOutput.stderr}`);
             }
-            return this.parseInstalledVersion(stdout);
+            /**
+             * Install dotnet over the latest version of
+             * dotnet CLI
+             */
+            const dotnetInstallOutput = yield new DotnetInstallScript()
+                // Don't overwrite CLI because it should be already installed
+                .useArguments(utils_1.IS_WINDOWS ? '-SkipNonVersionedFiles' : '--skip-non-versioned-files')
+                // Use version provided by user
+                .useVersion(dotnetVersion, this.quality)
+                .execute();
+            if (dotnetInstallOutput.exitCode) {
+                throw new Error(`Failed to install dotnet, exit code: ${dotnetInstallOutput.exitCode}. ${dotnetInstallOutput.stderr}`);
+            }
+            return this.parseInstalledVersion(dotnetInstallOutput.stdout);
         });
     }
     parseInstalledVersion(stdout) {


### PR DESCRIPTION
**Description**
- Added LTS runtime installation before requested dotnet installation:
When dotnet is installed after usage of some other version, [install script fails to override dotnet.exe](https://github.com/nikolai-laevskii/setup-dotnet/actions/runs/4961107288/jobs/8877470722) as it appears to be used by a process. Workaround is to pass `--skip-unversioned-files` flag to the install script and avoid overriding this file altogether. However, to ensure better compatibility and to avoid vulnerability issues, LTS runtime is now installed first, providing up-to-date unversioned files (such as CLI) for further usage.
- Added E2E tests that check for the problem described in the issue
  - Additional E2E tests were added to address this issue in the future.
  - The new E2E test failing on the [main branch](https://github.com/nikolai-laevskii/setup-dotnet/pull/4) with an error as described in the issue: https://github.com/nikolai-laevskii/setup-dotnet/actions/runs/4961107288/jobs/8877470722

**Related issue:** 
https://github.com/actions/setup-dotnet/issues/387

**Check list:**
- [ ] Mark if documentation changes are required.
- [x] Mark if tests were added or updated to cover the changes..