### PR TITLE
feat: support global.json rollForward latest variants

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -203,7 +203,82 @@ jobs:
       - name: Verify dotnet
         shell: pwsh
         run: __tests__/verify-dotnet.ps1 -Patterns "^2.2", "^3.1"
-
+        
+  test-setup-global-json-rollforward-latestminor:
+    runs-on: ${{ matrix.operating-system }}
+    strategy:
+      fail-fast: false
+      matrix:
+        operating-system: [ ubuntu-latest, windows-latest, macOS-latest ]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Clear toolcache
+        shell: pwsh
+        run: __tests__/clear-toolcache.ps1 ${{ runner.os }}
+      - name: Write global.json
+        shell: bash
+        run: |
+          mkdir subdirectory
+          echo '{"sdk":{"version": "3.0.100","rollForward": "latestMinor"}}' > ./subdirectory/global.json
+      - name: Setup dotnet
+        uses: ./
+        with:
+          global-json-file: ./subdirectory/global.json
+      - name: Verify dotnet
+        shell: pwsh
+        run: __tests__/verify-dotnet.ps1 -Patterns "^3.1"
+  
+  test-setup-global-json-rollforward-latestfeature:
+    runs-on: ${{ matrix.operating-system }}
+    strategy:
+      fail-fast: false
+      matrix:
+        operating-system: [ ubuntu-latest, windows-latest, macOS-latest ]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Clear toolcache
+        shell: pwsh
+        run: __tests__/clear-toolcache.ps1 ${{ runner.os }}
+      - name: Write global.json
+        shell: bash
+        run: |
+          mkdir subdirectory
+          echo '{"sdk":{"version": "3.1.100","rollForward": "latestFeature"}}' > ./subdirectory/global.json
+      - name: Setup dotnet
+        uses: ./
+        with:
+          global-json-file: ./subdirectory/global.json
+      - name: Verify dotnet
+        shell: pwsh
+        run: __tests__/verify-dotnet.ps1 -Patterns "^3.1.4"
+  
+  test-setup-global-json-rollforward-latestpatch:
+    runs-on: ${{ matrix.operating-system }}
+    strategy:
+      fail-fast: false
+      matrix:
+        operating-system: [ ubuntu-latest, windows-latest, macOS-latest ]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Clear toolcache
+        shell: pwsh
+        run: __tests__/clear-toolcache.ps1 ${{ runner.os }}
+      - name: Write global.json
+        shell: bash
+        run: |
+          mkdir subdirectory
+          echo '{"sdk":{"version": "3.1.400","rollForward": "latestPatch"}}' > ./subdirectory/global.json
+      - name: Setup dotnet
+        uses: ./
+        with:
+          global-json-file: ./subdirectory/global.json
+      - name: Verify dotnet
+        shell: pwsh
+        run: __tests__/verify-dotnet.ps1 -Patterns "^3.1.426$"
+        
   test-setup-global-json-only:
     runs-on: ${{ matrix.operating-system }}
     strategy:

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -73235,9 +73235,27 @@ function getVersionFromGlobalJson(globalJsonPath) {
     if (globalJson.sdk && globalJson.sdk.version) {
         version = globalJson.sdk.version;
         const rollForward = globalJson.sdk.rollForward;
-        if (rollForward && rollForward === 'latestFeature') {
-            const [major, minor] = version.split('.');
-            version = `${major}.${minor}`;
+        if (rollForward && rollForward.startsWith('latest')) {
+            const [major, minor, featurePatch] = version.split('.');
+            const feature = featurePatch.substring(0, 1);
+
+            switch (rollForward) {
+                case 'latestMajor':
+                    version = '';
+                    break;
+
+                case 'latestMinor':
+                    version = `${major}`;
+                    break;
+
+                case 'latestFeature':
+                    version = `${major}.${minor}`;
+                    break;
+
+                case 'latestPatch':
+                    version = `${major}.${minor}.${feature}`
+                    break;
+            }
         }
     }
     return version;

--- a/src/setup-dotnet.ts
+++ b/src/setup-dotnet.ts
@@ -110,9 +110,27 @@ function getVersionFromGlobalJson(globalJsonPath: string): string {
   if (globalJson.sdk && globalJson.sdk.version) {
     version = globalJson.sdk.version;
     const rollForward = globalJson.sdk.rollForward;
-    if (rollForward && rollForward === 'latestFeature') {
-      const [major, minor] = version.split('.');
-      version = `${major}.${minor}`;
+    if (rollForward && rollForward.startsWith('latest')) {
+      const [major, minor, featurePatch] = version.split('.');
+      const feature = featurePatch.substring(0, 1);
+      
+      switch (rollForward) {
+        case 'latestMajor':
+          version = '';
+          break;
+          
+        case 'latestMinor':
+          version = `${major}`;
+          break;
+          
+        case 'latestFeature':
+          version = `${major}.${minor}`;
+          break;
+          
+        case 'latestPatch':
+          version = `${major}.${minor}.${feature}`
+          break;
+      }
     }
   }
   return version;

--- a/src/setup-dotnet.ts
+++ b/src/setup-dotnet.ts
@@ -120,11 +120,11 @@ function getVersionFromGlobalJson(globalJsonPath: string): string {
           break;
           
         case 'latestMinor':
-          version = `${major}`;
+          version = `${major}.x`;
           break;
           
         case 'latestFeature':
-          version = `${major}.${minor}`;
+          version = `${major}.${minor}.x`;
           break;
           
         case 'latestPatch':

--- a/src/setup-dotnet.ts
+++ b/src/setup-dotnet.ts
@@ -111,7 +111,7 @@ function getVersionFromGlobalJson(globalJsonPath: string): string {
     version = globalJson.sdk.version;
     const rollForward = globalJson.sdk.rollForward;
     if (rollForward && rollForward.startsWith('latest')) {
-      const [major, minor, featurePatch] = version.split('.');
+      const [major, minor, featurePatch] = (version || '').split('.');
       const feature = featurePatch.substring(0, 1);
       
       switch (rollForward) {

--- a/src/setup-dotnet.ts
+++ b/src/setup-dotnet.ts
@@ -128,7 +128,7 @@ function getVersionFromGlobalJson(globalJsonPath: string): string {
           break;
           
         case 'latestPatch':
-          version = `${major}.${minor}.${feature}`
+          version = `${major}.${minor}.${feature}xx`
           break;
       }
     }


### PR DESCRIPTION
**Description:**
This PR adds support for all of the `latest*` variants of rollForward option in the `global.json` file
- `latestMajor`
- `latestMinor`
- `latestFeature`
- `latestPatch`

**Related issue:**
https://github.com/actions/setup-dotnet/issues/448

**Check list:**
- [ ] Mark if documentation changes are required. **_<- I'm not sure?_**
- [x] Mark if tests were added or updated to cover the changes.


---

I'm not sure if it makes sense to add the same kind of test for `latestMajor` - it would break every time there's a new major release. If it weren't limited to regular expression checks, the test could provide an EOL sdk version such as `3.1.426`, and the test could make sure that the resolved major version is _greater than_ 3, but I'm not sure how to go about that.