### PR TITLE
feat: use ProxyAddress with Credential when passed to powershell script

### DIFF
--- a/externals/install-dotnet.ps1
+++ b/externals/install-dotnet.ps1
@@ -416,6 +416,13 @@ function GetHTTPResponse([Uri] $Uri, [bool]$HeaderOnly, [bool]$DisableRedirect, 
                     UseDefaultCredentials=$ProxyUseDefaultCredentials;
                     BypassList = $ProxyBypassList;
                 }
+                # If ProxyAddress is contained username and password, then set credentials
+                # e.g. http://(user):(pass)@...
+                if ($ProxyAddress -match '://(.*?):(.*?)@') {
+                    $proxyUsername = $matches[1]
+                    $proxyPassword = $matches[2]
+                    $HttpClientHandler.Proxy.Credentials = New-Object System.Net.NetworkCredential($proxyUsername, $proxyPassword)
+                }
             }       
             if ($DisableRedirect)
             {


### PR DESCRIPTION
**Description:**
In a proxy environment, such as in an enterprise, HTTP(S)_PROXY often takes the form of credentials.
When $ProxyAddress is passed in this format, PowerShell WebProxy does not use the authentication information by default. 
This PR aims to solve the above problem.

**Related issue:**
None.

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.