### PR TITLE
feat: add arch to cache key

### DIFF
--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -93479,7 +93479,8 @@ const restoreCache = (cacheDependencyPath) => __awaiter(void 0, void 0, void 0, 
         throw new Error('Some specified paths were not resolved, unable to cache dependencies.');
     }
     const platform = process.env.RUNNER_OS;
-    const primaryKey = `dotnet-cache-${platform}-${fileHash}`;
+    const arch = process.arch;
+    const primaryKey = `dotnet-cache-${platform}-${arch}-${fileHash}`;
     core.debug(`primary key is ${primaryKey}`);
     core.saveState(constants_1.State.CachePrimaryKey, primaryKey);
     const { 'global-packages': cachePath } = yield (0, cache_utils_1.getNuGetFolderPath)();

--- a/src/cache-restore.ts
+++ b/src/cache-restore.ts
@@ -17,7 +17,8 @@ export const restoreCache = async (cacheDependencyPath?: string) => {
   }
 
   const platform = process.env.RUNNER_OS;
-  const primaryKey = `dotnet-cache-${platform}-${fileHash}`;
+  const arch = process.arch;
+  const primaryKey = `dotnet-cache-${platform}-${arch}-${fileHash}`;
   core.debug(`primary key is ${primaryKey}`);
 
   core.saveState(State.CachePrimaryKey, primaryKey);


### PR DESCRIPTION
**Description:**

GitHub has added the arm64 runner, so arch should be used as part of the cache key. Otherwise, if there are `macos-13` `macos-14` running at the same time, the late executor will get the wrong cache.

**Related issue:**

https://github.com/actions/setup-python/pull/896

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.