### PR TITLE
feat: Add arguments for verbose output to installer script

### DIFF
--- a/__tests__/installer.test.ts
+++ b/__tests__/installer.test.ts
@@ -40,6 +40,7 @@ describe('installer tests', () => {
       it('should throw the error in case of non-zero exit code of the installation script. The error message should contain logs.', async () => {
         const inputVersion = '3.1.100';
         const inputQuality = '' as QualityOptions;
+        const inputVerbose = false;
         const errorMessage = 'fictitious error message!';
 
         getExecOutputSpy.mockImplementation(() => {
@@ -52,7 +53,8 @@ describe('installer tests', () => {
 
         const dotnetInstaller = new installer.DotnetCoreInstaller(
           inputVersion,
-          inputQuality
+          inputQuality,
+          inputVerbose
         );
         await expect(dotnetInstaller.installDotnet()).rejects.toThrow(
           `Failed to install dotnet, exit code: 1. ${errorMessage}`
@@ -62,6 +64,7 @@ describe('installer tests', () => {
       it('should return version of .NET SDK after installation complete', async () => {
         const inputVersion = '3.1.100';
         const inputQuality = '' as QualityOptions;
+        const inputVerbose = false;
         const stdout = `Fictitious dotnet version ${inputVersion} is installed`;
         getExecOutputSpy.mockImplementation(() => {
           return Promise.resolve({
@@ -74,7 +77,8 @@ describe('installer tests', () => {
 
         const dotnetInstaller = new installer.DotnetCoreInstaller(
           inputVersion,
-          inputQuality
+          inputQuality,
+          inputVerbose
         );
         const installedVersion = await dotnetInstaller.installDotnet();
 
@@ -84,6 +88,7 @@ describe('installer tests', () => {
       it(`should supply 'version' argument to the installation script if supplied version is in A.B.C syntax`, async () => {
         const inputVersion = '6.0.300';
         const inputQuality = '' as QualityOptions;
+        const inputVerbose = false;
         const stdout = `Fictitious dotnet version ${inputVersion} is installed`;
 
         getExecOutputSpy.mockImplementation(() => {
@@ -97,7 +102,8 @@ describe('installer tests', () => {
 
         const dotnetInstaller = new installer.DotnetCoreInstaller(
           inputVersion,
-          inputQuality
+          inputQuality,
+          inputVerbose
         );
 
         await dotnetInstaller.installDotnet();
@@ -122,6 +128,7 @@ describe('installer tests', () => {
       it(`should warn if the 'quality' input is set and the supplied version is in A.B.C syntax`, async () => {
         const inputVersion = '6.0.300';
         const inputQuality = 'ga' as QualityOptions;
+        const inputVerbose = false;
         const stdout = `Fictitious dotnet version ${inputVersion} is installed`;
         getExecOutputSpy.mockImplementation(() => {
           return Promise.resolve({
@@ -134,7 +141,8 @@ describe('installer tests', () => {
 
         const dotnetInstaller = new installer.DotnetCoreInstaller(
           inputVersion,
-          inputQuality
+          inputQuality,
+          inputVerbose
         );
 
         await dotnetInstaller.installDotnet();
@@ -147,6 +155,7 @@ describe('installer tests', () => {
       it(`should warn if the 'quality' input is set and version isn't in A.B.C syntax but major tag is lower then 6`, async () => {
         const inputVersion = '3.1';
         const inputQuality = 'ga' as QualityOptions;
+        const inputVerbose = false;
         const stdout = `Fictitious dotnet version 3.1.100 is installed`;
 
         getExecOutputSpy.mockImplementation(() => {
@@ -160,7 +169,8 @@ describe('installer tests', () => {
 
         const dotnetInstaller = new installer.DotnetCoreInstaller(
           inputVersion,
-          inputQuality
+          inputQuality,
+          inputVerbose
         );
 
         await dotnetInstaller.installDotnet();
@@ -174,6 +184,7 @@ describe('installer tests', () => {
         `should supply 'quality' argument to the installation script if quality input is set and version (%s) is not in A.B.C syntax`,
         async inputVersion => {
           const inputQuality = 'ga' as QualityOptions;
+          const inputVerbose = false;
           const exitCode = 0;
           const stdout = `Fictitious dotnet version 6.0.0 is installed`;
           getExecOutputSpy.mockImplementation(() => {
@@ -187,7 +198,8 @@ describe('installer tests', () => {
 
           const dotnetInstaller = new installer.DotnetCoreInstaller(
             inputVersion,
-            inputQuality
+            inputQuality,
+            inputVerbose
           );
 
           await dotnetInstaller.installDotnet();
@@ -214,6 +226,7 @@ describe('installer tests', () => {
         `should supply 'channel' argument to the installation script if version (%s) isn't in A.B.C syntax`,
         async inputVersion => {
           const inputQuality = '' as QualityOptions;
+          const inputVerbose = false;
           const exitCode = 0;
           const stdout = `Fictitious dotnet version 6.0.0 is installed`;
           getExecOutputSpy.mockImplementation(() => {
@@ -227,7 +240,8 @@ describe('installer tests', () => {
 
           const dotnetInstaller = new installer.DotnetCoreInstaller(
             inputVersion,
-            inputQuality
+            inputQuality,
+            inputVerbose
           );
 
           await dotnetInstaller.installDotnet();
@@ -250,11 +264,44 @@ describe('installer tests', () => {
         }
       );
 
+      it(`should supply 'verbose' argument to the installation script if verbose input is set`, async () => {
+        const inputVersion = '6.0.300';
+        const inputQuality = '' as QualityOptions;
+        const inputVerbose = true;
+        const stdout = `Fictitious dotnet version ${inputVersion} is installed`;
+
+        getExecOutputSpy.mockImplementation(() => {
+          return Promise.resolve({
+            exitCode: 0,
+            stdout: `${stdout}`,
+            stderr: ''
+          });
+        });
+        maxSatisfyingSpy.mockImplementation(() => inputVersion);
+
+        const dotnetInstaller = new installer.DotnetCoreInstaller(
+          inputVersion,
+          inputQuality,
+          inputVerbose
+        );
+
+        await dotnetInstaller.installDotnet();
+
+        const scriptArguments = getExecOutputSpy.mock.calls.map(call =>
+          (call[1] as string[]).join(' ')
+        );
+        const expectedArgument = IS_WINDOWS ? '-Verbose' : '--verbose';
+
+        expect(scriptArguments[0]).toContain(expectedArgument);
+        expect(scriptArguments[1]).toContain(expectedArgument);
+      });
+
       if (IS_WINDOWS) {
         it(`should supply '-ProxyAddress' argument to the installation script if env.variable 'https_proxy' is set`, async () => {
           process.env['https_proxy'] = 'https://proxy.com';
           const inputVersion = '6.0.100';
           const inputQuality = '' as QualityOptions;
+          const inputVerbose = false;
           const stdout = `Fictitious dotnet version ${inputVersion} is installed`;
 
           getExecOutputSpy.mockImplementation(() => {
@@ -268,7 +315,8 @@ describe('installer tests', () => {
 
           const dotnetInstaller = new installer.DotnetCoreInstaller(
             inputVersion,
-            inputQuality
+            inputQuality,
+            inputVerbose
           );
 
           await dotnetInstaller.installDotnet();
@@ -293,6 +341,7 @@ describe('installer tests', () => {
           process.env['no_proxy'] = 'first.url,second.url';
           const inputVersion = '6.0.100';
           const inputQuality = '' as QualityOptions;
+          const inputVerbose = false;
           const stdout = `Fictitious dotnet version 6.0.0 is installed`;
 
           getExecOutputSpy.mockImplementation(() => {
@@ -306,7 +355,8 @@ describe('installer tests', () => {
 
           const dotnetInstaller = new installer.DotnetCoreInstaller(
             inputVersion,
-            inputQuality
+            inputQuality,
+            inputVerbose
           );
 
           await dotnetInstaller.installDotnet();

--- a/action.yml
+++ b/action.yml
@@ -20,10 +20,14 @@ inputs:
   cache:
     description: 'Optional input to enable caching of the NuGet global-packages folder'
     required: false
-    default: false
+    default: 'false'
   cache-dependency-path:
     description: 'Used to specify the path to a dependency file: packages.lock.json. Supports wildcards or a list of file names for caching multiple dependencies.'
     required: false
+  verbose:
+    description: 'Optional input to enable verbose output of installer script'
+    required: false
+    default: 'false'
 outputs:
   cache-hit:
     description: 'A boolean value to indicate if a cache was hit.'

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -93879,6 +93879,12 @@ class DotnetInstallScript {
         }
         return this;
     }
+    enableVerbose(verbose) {
+        if (verbose) {
+            this.useArguments(utils_1.IS_WINDOWS ? '-Verbose' : '--verbose');
+        }
+        return this;
+    }
     execute() {
         return __awaiter(this, void 0, void 0, function* () {
             const getExecOutputOptions = {
@@ -93917,9 +93923,10 @@ DotnetInstallDir.dirPath = process.env['DOTNET_INSTALL_DIR']
     ? DotnetInstallDir.convertInstallPathToAbsolute(process.env['DOTNET_INSTALL_DIR'])
     : DotnetInstallDir.default[utils_1.PLATFORM];
 class DotnetCoreInstaller {
-    constructor(version, quality) {
+    constructor(version, quality, verbose) {
         this.version = version;
         this.quality = quality;
+        this.verbose = verbose;
     }
     installDotnet() {
         return __awaiter(this, void 0, void 0, function* () {
@@ -93936,6 +93943,8 @@ class DotnetCoreInstaller {
                 .useArguments(utils_1.IS_WINDOWS ? '-Runtime' : '--runtime', 'dotnet')
                 // Use latest stable version
                 .useArguments(utils_1.IS_WINDOWS ? '-Channel' : '--channel', 'LTS')
+                // Enable verbose output depending on user input
+                .enableVerbose(this.verbose)
                 .execute();
             if (runtimeInstallOutput.exitCode) {
                 /**
@@ -93953,6 +93962,8 @@ class DotnetCoreInstaller {
                 .useArguments(utils_1.IS_WINDOWS ? '-SkipNonVersionedFiles' : '--skip-non-versioned-files')
                 // Use version provided by user
                 .useVersion(dotnetVersion, this.quality)
+                // Enable verbose output depending on user input
+                .enableVerbose(this.verbose)
                 .execute();
             if (dotnetInstallOutput.exitCode) {
                 throw new Error(`Failed to install dotnet, exit code: ${dotnetInstallOutput.exitCode}. ${dotnetInstallOutput.stderr}`);
@@ -94072,13 +94083,14 @@ function run() {
             }
             if (versions.length) {
                 const quality = core.getInput('dotnet-quality');
+                const verbose = core.getBooleanInput('verbose');
                 if (quality && !qualityOptions.includes(quality)) {
                     throw new Error(`Value '${quality}' is not supported for the 'dotnet-quality' option. Supported values are: daily, signed, validated, preview, ga.`);
                 }
                 let dotnetInstaller;
                 const uniqueVersions = new Set(versions);
                 for (const version of uniqueVersions) {
-                    dotnetInstaller = new installer_1.DotnetCoreInstaller(version, quality);
+                    dotnetInstaller = new installer_1.DotnetCoreInstaller(version, quality, verbose);
                     const installedVersion = yield dotnetInstaller.installDotnet();
                     installedDotnetVersions.push(installedVersion);
                 }

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -201,6 +201,14 @@ export class DotnetInstallScript {
     return this;
   }
 
+  public enableVerbose(verbose: boolean) {
+    if (verbose) {
+      this.useArguments(IS_WINDOWS ? '-Verbose' : '--verbose');
+    }
+
+    return this;
+  }
+
   public async execute() {
     const getExecOutputOptions = {
       ignoreReturnCode: true,
@@ -255,7 +263,8 @@ export class DotnetCoreInstaller {
 
   constructor(
     private version: string,
-    private quality: QualityOptions
+    private quality: QualityOptions,
+    private verbose: boolean
   ) {}
 
   public async installDotnet(): Promise<string | null> {
@@ -275,6 +284,8 @@ export class DotnetCoreInstaller {
       .useArguments(IS_WINDOWS ? '-Runtime' : '--runtime', 'dotnet')
       // Use latest stable version
       .useArguments(IS_WINDOWS ? '-Channel' : '--channel', 'LTS')
+      // Enable verbose output depending on user input
+      .enableVerbose(this.verbose)
       .execute();
 
     if (runtimeInstallOutput.exitCode) {
@@ -298,6 +309,8 @@ export class DotnetCoreInstaller {
       )
       // Use version provided by user
       .useVersion(dotnetVersion, this.quality)
+      // Enable verbose output depending on user input
+      .enableVerbose(this.verbose)
       .execute();
 
     if (dotnetInstallOutput.exitCode) {

--- a/src/setup-dotnet.ts
+++ b/src/setup-dotnet.ts
@@ -59,6 +59,7 @@ export async function run() {
 
     if (versions.length) {
       const quality = core.getInput('dotnet-quality') as QualityOptions;
+      const verbose = core.getBooleanInput('verbose');
 
       if (quality && !qualityOptions.includes(quality)) {
         throw new Error(
@@ -69,7 +70,7 @@ export async function run() {
       let dotnetInstaller: DotnetCoreInstaller;
       const uniqueVersions = new Set<string>(versions);
       for (const version of uniqueVersions) {
-        dotnetInstaller = new DotnetCoreInstaller(version, quality);
+        dotnetInstaller = new DotnetCoreInstaller(version, quality, verbose);
         const installedVersion = await dotnetInstaller.installDotnet();
         installedDotnetVersions.push(installedVersion);
       }


### PR DESCRIPTION
**Description:**
When something went wrong without an error message or you just want to see what the installer script is actually doing, you want that this action adds `-Verbose`/`--verbose` arguments to the installer script.
This PR solves this with a new action input parameter.

**Related issue:**
None.

**Check list:**
- [ ] Mark if documentation changes are required.
- [x] Mark if tests were added or updated to cover the changes.