### PR TITLE
v3 - Remove `azureedge.net` fallback and update install scripts

### DIFF
--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -71286,7 +71286,6 @@ class DotnetVersionResolver {
 }
 exports.DotnetVersionResolver = DotnetVersionResolver;
 DotnetVersionResolver.DotNetCoreIndexUrl = 'https://builds.dotnet.microsoft.com/dotnet/release-metadata/releases-index.json';
-DotnetVersionResolver.DotnetCoreIndexFallbackUrl = 'https://dotnetcli.azureedge.net/dotnet/release-metadata/releases-index.json';
 class DotnetCoreInstaller {
     constructor(version, quality) {
         this.version = version;

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -102,16 +102,9 @@ export class DotnetVersionResolver {
       maxRetries: 3
     });
 
-    let response;
-    try {
-      response = await httpClient.getJson<any>(
-        DotnetVersionResolver.DotNetCoreIndexUrl
-      );
-    } catch (error) {
-      response = await httpClient.getJson<any>(
-        DotnetVersionResolver.DotnetCoreIndexFallbackUrl
-      );
-    }
+    const response = await httpClient.getJson<any>(
+      DotnetVersionResolver.DotNetCoreIndexUrl
+    );
 
     const result = response.result || {};
     const releasesInfo: any[] = result['releases-index'];
@@ -132,9 +125,6 @@ export class DotnetVersionResolver {
 
   static DotNetCoreIndexUrl =
     'https://builds.dotnet.microsoft.com/dotnet/release-metadata/releases-index.json';
-
-  static DotnetCoreIndexFallbackUrl =
-    'https://dotnetcli.azureedge.net/dotnet/release-metadata/releases-index.json';
 }
 
 export class DotnetCoreInstaller {


### PR DESCRIPTION
In response to https://github.com/dotnet/install-scripts/issues/559, we want to remove the CDN fallback logic added for v3 in #567 and update the install scripts once those changes are completed.

This PR currently:
- Removes the fallback logic

**Related issue:** https://github.com/dotnet/install-scripts/issues/559

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.