### PR TITLE
v2 - Remove `dotnetcli.blob.core.windows.net` storage account fallback logic and update install scripts

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -379,13 +379,8 @@ class DotnetCoreInstaller {
     }
     getReleasesJsonUrl(httpClient, versionParts) {
         return __awaiter(this, void 0, void 0, function* () {
-            let response;
-            try {
-                response = yield httpClient.getJson(DotNetCoreIndexUrl);
-            }
-            catch (error) {
-                response = yield httpClient.getJson(DotnetCoreIndexFallbackUrl);
-            }
+            const response = yield httpClient.getJson(DotNetCoreIndexUrl);
+
             const result = response.result || {};
             let releasesInfo = result['releases-index'];
             releasesInfo = releasesInfo.filter((info) => {
@@ -410,7 +405,6 @@ class DotnetCoreInstaller {
 }
 exports.DotnetCoreInstaller = DotnetCoreInstaller;
 const DotNetCoreIndexUrl = 'https://builds.dotnet.microsoft.com/dotnet/release-metadata/releases-index.json';
-const DotnetCoreIndexFallbackUrl = 'https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/releases-index.json';
 
 
 /***/ }),

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -262,12 +262,8 @@ export class DotnetCoreInstaller {
     httpClient: hc.HttpClient,
     versionParts: string[]
   ): Promise<string> {
-    let response;
-    try {
-      response = await httpClient.getJson<any>(DotNetCoreIndexUrl);
-    } catch (error) {
-      response = await httpClient.getJson<any>(DotnetCoreIndexFallbackUrl);
-    }
+    const response = await httpClient.getJson<any>(DotNetCoreIndexUrl);
+
     const result = response.result || {};
     let releasesInfo: any[] = result['releases-index'];
 
@@ -307,6 +303,3 @@ export class DotnetCoreInstaller {
 
 const DotNetCoreIndexUrl: string =
   'https://builds.dotnet.microsoft.com/dotnet/release-metadata/releases-index.json';
-
-const DotnetCoreIndexFallbackUrl: string =
-  'https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/releases-index.json';


### PR DESCRIPTION
In response to the call to action outlined in https://devblogs.microsoft.com/dotnet/critical-dotnet-install-links-are-changing/, we want to remove the storage account fallback logic added for `v2` in #568 and update the install scripts once those changes are completed.

This PR currently:
- Removes the fallback logic

**Related issue:** https://github.com/dotnet/install-scripts/issues/559

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.