### PR TITLE
Add msbuild.json as problem matcher (#603)

### DIFF
--- a/.github/msbuild.json
+++ b/.github/msbuild.json
@@ -1,0 +1,17 @@
+{
+    "problemMatcher": [
+        {
+            "owner": "msbuild",
+            "pattern": [
+                {
+                    "regexp": "^([^\\s].*)\\s+:\\s+(error|warning)\\s+([a-zA-Z]+(?<!MSB)\\d+):\\s*(.*?)\\s+\\[(.*?)\\]$",
+                    "file": 1,
+                    "severity": 2,
+                    "code": 3,
+                    "message": 4,
+                    "fromPath": 5
+                }
+            ]
+        }
+    ]
+}

--- a/__tests__/msbuild.test.ts
+++ b/__tests__/msbuild.test.ts
@@ -1,0 +1,46 @@
+import msbuildFile from '../.github/msbuild.json';
+describe('msbuild tests', () => {
+  test('regular expression in msbuild.json is valid', async () => {
+    const regexPattern =
+      msbuildFile['problemMatcher'][0]['pattern'][0]['regexp'];
+    const regexResultsMap = msbuildFile['problemMatcher'][0]['pattern'][0];
+
+    const regex = new RegExp(regexPattern);
+
+    const stringsToMatch = [
+      "/Users/zacharyeisinger/Documents/repo/setup-dotnet/__tests__/sample-broken-csproj/sample.csproj : warning NU1904: Package 'System.Text.Encodings.Web' 4.7.0 has a known critical severity vulnerability, https://github.com/advisories/GHSA-ghhp-997w-qr28 [/Users/zacharyeisinger/Documents/repo/setup-dotnet/__tests__/sample-broken-csproj/sample.csproj]",
+      "/Users/zacharyeisinger/Documents/repo/setup-dotnet/__tests__/sample-broken-csproj/sample.csproj : error NU1904: Package 'System.Text.Encodings.Web' 4.7.0 has a known critical severity vulnerability, https://github.com/advisories/GHSA-ghhp-997w-qr28 [/Users/zacharyeisinger/Documents/repo/setup-dotnet/__tests__/sample-broken-csproj/sample.csproj]"
+    ];
+    // Expected results are calculated according to the msbuild matcher located in msbuild.json file
+    const expectedResults = [
+      {
+        file: '/Users/zacharyeisinger/Documents/repo/setup-dotnet/__tests__/sample-broken-csproj/sample.csproj',
+        severity: 'warning',
+        code: 'NU1904',
+        message:
+          "Package 'System.Text.Encodings.Web' 4.7.0 has a known critical severity vulnerability, https://github.com/advisories/GHSA-ghhp-997w-qr28",
+        fromPath:
+          '/Users/zacharyeisinger/Documents/repo/setup-dotnet/__tests__/sample-broken-csproj/sample.csproj'
+      },
+      {
+        file: '/Users/zacharyeisinger/Documents/repo/setup-dotnet/__tests__/sample-broken-csproj/sample.csproj',
+        severity: 'error',
+        code: 'NU1904',
+        message:
+          "Package 'System.Text.Encodings.Web' 4.7.0 has a known critical severity vulnerability, https://github.com/advisories/GHSA-ghhp-997w-qr28",
+        fromPath:
+          '/Users/zacharyeisinger/Documents/repo/setup-dotnet/__tests__/sample-broken-csproj/sample.csproj'
+      }
+    ];
+
+    stringsToMatch.map((string, index) => {
+      const matchedResultsArray = string.match(regex);
+      for (const propName in expectedResults[index]) {
+        const propertyIndex = regexResultsMap[propName];
+        const expectedPropValue = expectedResults[index][propName];
+        const matchedPropValue = matchedResultsArray![propertyIndex];
+        expect(matchedPropValue).toEqual(expectedPropValue);
+      }
+    });
+  }, 10000);
+});

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -102523,6 +102523,7 @@ function run() {
             }
             const matchersPath = path_1.default.join(__dirname, '..', '..', '.github');
             core.info(`##[add-matcher]${path_1.default.join(matchersPath, 'csc.json')}`);
+            core.info(`##[add-matcher]${path_1.default.join(matchersPath, 'msbuild.json')}`);
         }
         catch (error) {
             core.setFailed(error.message);

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,8 +18,7 @@
         "@actions/io": "^1.0.2",
         "fast-xml-parser": "^4.4.1",
         "json5": "^2.2.3",
-        "semver": "^7.6.0",
-        "undici": "^5.28.5"
+        "semver": "^7.6.0"
       },
       "devDependencies": {
         "@types/jest": "^29.5.12",

--- a/src/setup-dotnet.ts
+++ b/src/setup-dotnet.ts
@@ -91,6 +91,7 @@ export async function run() {
 
     const matchersPath = path.join(__dirname, '..', '..', '.github');
     core.info(`##[add-matcher]${path.join(matchersPath, 'csc.json')}`);
+    core.info(`##[add-matcher]${path.join(matchersPath, 'msbuild.json')}`);
   } catch (error) {
     core.setFailed(error.message);
   }


### PR DESCRIPTION
**Description:**
Added `msbuild.json` as seperately owned matched. This makes it possible to disable it seperately. Tests are added and I used it in our CI pipeline already.

**Related issue:**
https://github.com/actions/setup-dotnet/issues/603

**Check list:**
- [ ] Mark if documentation changes are required.
- [X] Mark if tests were added or updated to cover the changes.