### PR TITLE
V3 - Add workflow file for publishing releases to immutable action package

### DIFF
--- a/.github/workflows/publish-immutable-actions.yml
+++ b/.github/workflows/publish-immutable-actions.yml
@@ -1,0 +1,20 @@
+name: 'Publish Immutable Action Version'
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
+
+    steps:
+      - name: Checking out
+        uses: actions/checkout@v4
+      - name: Publish
+        id: publish
+        uses: actions/publish-immutable-action@v0.0.4


### PR DESCRIPTION
**Description:**

This workflow file publishes new action releases to the immutable action package of the same name as this repo.

This is part of the Immutable Actions project which is not yet fully released to the public. First party actions like this one are part of our initial testing of this feature.