### PR TITLE
Remove Support for older .NET Versions and Update installers scripts

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -24,17 +24,16 @@ jobs:
       - name: Clear toolcache
         shell: pwsh
         run: __tests__/clear-toolcache.ps1 ${{ runner.os }}
-      - name: Setup dotnet 2.2.402, 3.1.404 and 3.0.x
+      - name: Setup dotnet 6.0.427, 7.0.410 and 7.0.x
         uses: ./
         with:
           dotnet-version: |
-            2.2.402
-            3.1.404
-            3.0.x
+            6.0.427
+            7.0.410
+            7.0.x
       - name: Verify dotnet
         shell: pwsh
-        run: __tests__/verify-dotnet.ps1 -Patterns "^2.2.402$", "^3.1.404$", "^3.0"
-
+        run: __tests__/verify-dotnet.ps1 -Patterns "^6.0.427$", "^7.0.410$", "^7.0"
   test-setup-multiple-versions-extended:
     runs-on: ${{ matrix.operating-system }}
     strategy:
@@ -47,17 +46,16 @@ jobs:
       - name: Clear toolcache
         shell: pwsh
         run: __tests__/clear-toolcache.ps1 ${{ runner.os }}
-      - name: Setup dotnet 6.0.427, 8.0.403 and 8.0.x
+      - name: Setup dotnet 8.0.403, 9.0.301 and 8.0.x
         uses: ./
         with:
           dotnet-version: |
-            6.0.427
             8.0.403
+            9.0.301
             8.0.x
       - name: Verify dotnet
         shell: pwsh
-        run: __tests__/verify-dotnet.ps1 -Patterns "^6.0.427$", "^8.0.403$", "^8.0"
-
+        run: __tests__/verify-dotnet.ps1 -Patterns "^8.0.403$", "^9.0.301$", "^8.0"
   test-setup-full-version:
     runs-on: ${{ matrix.operating-system }}
     strategy:
@@ -70,23 +68,22 @@ jobs:
       - name: Clear toolcache
         shell: pwsh
         run: __tests__/clear-toolcache.ps1 ${{ runner.os }}
-      # Side-by-side install of 2.2 and 3.1 used for the test project
-      - name: Setup dotnet 2.2.402
+      # Side-by-side install of 6.0 and 7.0 used for the test project
+      - name: Setup dotnet 6.0.427
         uses: ./
         with:
-          dotnet-version: 2.2.402
-      - name: Setup dotnet 3.1.201
+          dotnet-version: 6.0.427
+      - name: Setup dotnet 7.0.410
         uses: ./
         with:
-          dotnet-version: 3.1.201
+          dotnet-version: 7.0.410
           # We are including this variable to force the generation of the nuget config file to verify that it is created in the correct place
           source-url: https://api.nuget.org/v3/index.json
         env:
           NUGET_AUTH_TOKEN: NOTATOKEN
       - name: Verify dotnet
         shell: pwsh
-        run: __tests__/verify-dotnet.ps1 -Patterns "^3.1.201$", "^2.2.402$" -CheckNugetConfig
-
+        run: __tests__/verify-dotnet.ps1 -Patterns "^7.0.410$", "^6.0.427$" -CheckNugetConfig
   test-setup-full-version-extended:
     runs-on: ${{ matrix.operating-system }}
     strategy:
@@ -99,23 +96,22 @@ jobs:
       - name: Clear toolcache
         shell: pwsh
         run: __tests__/clear-toolcache.ps1 ${{ runner.os }}
-      # Side-by-side install of 6.0 and 8.0 used for the test project
-      - name: Setup dotnet 6.0.427
-        uses: ./
-        with:
-          dotnet-version: 6.0.427
+      # Side-by-side install of 8.0 and 9.0 used for the test project
       - name: Setup dotnet 8.0.402
         uses: ./
         with:
           dotnet-version: 8.0.402
+      - name: Setup dotnet 9.0.301
+        uses: ./
+        with:
+          dotnet-version: 9.0.301
           # We are including this variable to force the generation of the nuget config file to verify that it is created in the correct place
           source-url: https://api.nuget.org/v3/index.json
         env:
           NUGET_AUTH_TOKEN: NOTATOKEN
       - name: Verify dotnet
         shell: pwsh
-        run: __tests__/verify-dotnet.ps1 -Patterns "^8.0.402$", "^6.0.427$" -CheckNugetConfig
-
+        run: __tests__/verify-dotnet.ps1 -Patterns "^9.0.301$", "^8.0.402$" -CheckNugetConfig
   test-setup-without-patch-version:
     runs-on: ${{ matrix.operating-system }}
     strategy:
@@ -128,19 +124,18 @@ jobs:
       - name: Clear toolcache
         shell: pwsh
         run: __tests__/clear-toolcache.ps1 ${{ runner.os }}
-      # 2.0, 3.0, 5.0 needs to be in single quotes to interpret as a string instead of as an integer
-      - name: Setup dotnet '3.1'
+      # 6.0, 7.0 needs to be in single quotes to interpret as a string instead of as an integer
+      - name: Setup dotnet '6.0'
         uses: ./
         with:
-          dotnet-version: '3.1'
-      - name: Setup dotnet '2.2'
+          dotnet-version: '6.0'
+      - name: Setup dotnet '7.0'
         uses: ./
         with:
-          dotnet-version: '2.2'
+          dotnet-version: '7.0'
       - name: Verify dotnet
         shell: pwsh
-        run: __tests__/verify-dotnet.ps1 -Patterns "^3.1", "^2.2"
-
+        run: __tests__/verify-dotnet.ps1 -Patterns "^6.0", "^7.0"
   test-setup-without-patch-version-extended:
     runs-on: ${{ matrix.operating-system }}
     strategy:
@@ -153,19 +148,18 @@ jobs:
       - name: Clear toolcache
         shell: pwsh
         run: __tests__/clear-toolcache.ps1 ${{ runner.os }}
-      # 6.0, 7.0, 8.0 needs to be in single quotes to interpret as a string instead of as an integer
+      # 8.0, 9.0 needs to be in single quotes to interpret as a string instead of as an integer
       - name: Setup dotnet '8.0'
         uses: ./
         with:
           dotnet-version: '8.0'
-      - name: Setup dotnet '6.0'
+      - name: Setup dotnet '9.0'
         uses: ./
         with:
-          dotnet-version: '6.0'
+          dotnet-version: '9.0'
       - name: Verify dotnet
         shell: pwsh
-        run: __tests__/verify-dotnet.ps1 -Patterns "^8.0", "^6.0"
-
+        run: __tests__/verify-dotnet.ps1 -Patterns "^8.0", "^9.0"
   test-setup-prerelease-version:
     runs-on: ${{ matrix.operating-system }}
     strategy:
@@ -178,13 +172,13 @@ jobs:
       - name: Clear toolcache
         shell: pwsh
         run: __tests__/clear-toolcache.ps1 ${{ runner.os }}
-      - name: Setup dotnet '3.1.100-preview1-014459'
+      - name: Setup dotnet '6.0.100-preview.7.21379.14'
         uses: ./
         with:
-          dotnet-version: '3.1.100-preview1-014459'
+          dotnet-version: '6.0.100-preview.7.21379.14'
       - name: Verify dotnet
         shell: pwsh
-        run: __tests__/verify-dotnet.ps1 -Patterns "3.1.100-preview1-014459"
+        run: __tests__/verify-dotnet.ps1 -Patterns "6.0.100-preview.7.21379.14"
 
   test-setup-prerelease-version-extended:
     runs-on: ${{ matrix.operating-system }}
@@ -218,18 +212,17 @@ jobs:
       - name: Clear toolcache
         shell: pwsh
         run: __tests__/clear-toolcache.ps1 ${{ runner.os }}
-      - name: Setup dotnet 3.1.x
+      - name: Setup dotnet 6.0.x
         uses: ./
         with:
-          dotnet-version: 3.1.x
-      - name: Setup dotnet 2.2.X
+          dotnet-version: 6.0.x
+      - name: Setup dotnet 7.0.X
         uses: ./
         with:
-          dotnet-version: 2.2.X
+          dotnet-version: 7.0.X
       - name: Verify dotnet
         shell: pwsh
-        run: __tests__/verify-dotnet.ps1 -Patterns "^2.2", "^3.1"
-
+        run: __tests__/verify-dotnet.ps1 -Patterns "^6.0", "^7.0"
   test-setup-latest-patch-version-extended:
     runs-on: ${{ matrix.operating-system }}
     strategy:
@@ -246,13 +239,13 @@ jobs:
         uses: ./
         with:
           dotnet-version: 8.0.x
-      - name: Setup dotnet 6.0.X
+      - name: Setup dotnet 9.0.X
         uses: ./
         with:
-          dotnet-version: 6.0.X
+          dotnet-version: 9.0.X
       - name: Verify dotnet
         shell: pwsh
-        run: __tests__/verify-dotnet.ps1 -Patterns "^6.0", "^8.0"
+        run: __tests__/verify-dotnet.ps1 -Patterns "^8.0", "^9.0"
 
   test-ABCxx-syntax:
     runs-on: ${{ matrix.operating-system }}
@@ -288,18 +281,17 @@ jobs:
       - name: Clear toolcache
         shell: pwsh
         run: __tests__/clear-toolcache.ps1 ${{ runner.os }}
-      - name: Setup dotnet 3.1.*
+      - name: Setup dotnet 6.0.*
         uses: ./
         with:
-          dotnet-version: 3.1.*
-      - name: Setup dotnet 2.2.*
+          dotnet-version: 6.0.*
+      - name: Setup dotnet 7.0.*
         uses: ./
         with:
-          dotnet-version: 2.2.*
+          dotnet-version: 7.0.*
       - name: Verify dotnet
         shell: pwsh
-        run: __tests__/verify-dotnet.ps1 -Patterns "^3.1", "^2.2"
-
+        run: __tests__/verify-dotnet.ps1 -Patterns "^6.0", "^7.0"
   test-setup-with-wildcard-extended:
     runs-on: ${{ matrix.operating-system }}
     strategy:
@@ -316,13 +308,13 @@ jobs:
         uses: ./
         with:
           dotnet-version: 8.0.*
-      - name: Setup dotnet 6.0.*
+      - name: Setup dotnet 9.0.*
         uses: ./
         with:
-          dotnet-version: 6.0.*
+          dotnet-version: 9.0.*
       - name: Verify dotnet
         shell: pwsh
-        run: __tests__/verify-dotnet.ps1 -Patterns "^8.0", "^6.0"
+        run: __tests__/verify-dotnet.ps1 -Patterns "^8.0", "^9.0"
 
   test-setup-global-json-specified-and-version:
     runs-on: ${{ matrix.operating-system }}
@@ -340,16 +332,15 @@ jobs:
         shell: bash
         run: |
           mkdir subdirectory
-          echo '{"sdk":{"version": "2.2.207","rollForward": "latestFeature"}}' > ./subdirectory/global.json
+          echo '{"sdk":{"version": "6.0.424","rollForward": "latestFeature"}}' > ./subdirectory/global.json
       - name: Setup dotnet
         uses: ./
         with:
-          dotnet-version: 3.1
+          dotnet-version: 7.0
           global-json-file: ./subdirectory/global.json
       - name: Verify dotnet
         shell: pwsh
-        run: __tests__/verify-dotnet.ps1 -Patterns "^2.2", "^3.1"
-
+        run: __tests__/verify-dotnet.ps1 -Patterns "^6.0", "^7.0"
   test-setup-global-json-specified-and-version-extended:
     runs-on: ${{ matrix.operating-system }}
     strategy:
@@ -366,15 +357,15 @@ jobs:
         shell: bash
         run: |
           mkdir subdirectory
-          echo '{"sdk":{"version": "6.0.424","rollForward": "latestFeature"}}' > ./subdirectory/global.json
+          echo '{"sdk":{"version": "8.0.402","rollForward": "latestFeature"}}' > ./subdirectory/global.json
       - name: Setup dotnet
         uses: ./
         with:
-          dotnet-version: '8.0'
+          dotnet-version: '9.0'
           global-json-file: ./subdirectory/global.json
       - name: Verify dotnet
         shell: pwsh
-        run: __tests__/verify-dotnet.ps1 -Patterns "^6.0", "^8.0"
+        run: __tests__/verify-dotnet.ps1 -Patterns "^8.0", "^9.0"
 
   test-setup-global-json-only:
     runs-on: ${{ matrix.operating-system }}
@@ -392,14 +383,14 @@ jobs:
         shell: bash
         run: |
           mkdir subdirectory
-          echo '{"sdk":{"version": "2.2.207","rollForward": "latestFeature"}}' > ./subdirectory/global.json
+          echo '{"sdk":{"version": "6.0.424","rollForward": "latestFeature"}}' > ./subdirectory/global.json
       - name: Setup dotnet
         uses: ./
         with:
           global-json-file: ./subdirectory/global.json
       - name: Verify dotnet
         shell: pwsh
-        run: __tests__/verify-dotnet.ps1 -Patterns "^2.2"
+        run: __tests__/verify-dotnet.ps1 -Patterns "^6.0"
 
   test-setup-global-json-only-extended:
     runs-on: ${{ matrix.operating-system }}
@@ -442,14 +433,14 @@ jobs:
         shell: bash
         run: |
           mkdir subdirectory
-          echo '/* should support comments */ {"sdk":{"version": "2.2.207","rollForward": "latestFeature"}} // should support comments' > ./subdirectory/global.json
+          echo '/* should support comments */ {"sdk":{"version": "6.0.424","rollForward": "latestFeature"}} // should support comments' > ./subdirectory/global.json
       - name: Setup dotnet
         uses: ./
         with:
           global-json-file: ./subdirectory/global.json
       - name: Verify dotnet
         shell: pwsh
-        run: __tests__/verify-dotnet.ps1 -Patterns "^2.2"
+        run: __tests__/verify-dotnet.ps1 -Patterns "^6.0"
 
   test-global-json-with-comments-extended:
     runs-on: ${{ matrix.operating-system }}
@@ -467,14 +458,14 @@ jobs:
         shell: bash
         run: |
           mkdir subdirectory
-          echo '/* should support comments */ {"sdk":{"version": "6.0.424","rollForward": "latestFeature"}} // should support comments' > ./subdirectory/global.json
+          echo '/* should support comments */ {"sdk":{"version": "8.0.402","rollForward": "latestFeature"}} // should support comments' > ./subdirectory/global.json
       - name: Setup dotnet
         uses: ./
         with:
           global-json-file: ./subdirectory/global.json
       - name: Verify dotnet
         shell: pwsh
-        run: __tests__/verify-dotnet.ps1 -Patterns "^6.0"
+        run: __tests__/verify-dotnet.ps1 -Patterns "^8.0"
 
   test-setup-with-dotnet-quality:
     runs-on: ${{ matrix.operating-system }}
@@ -516,11 +507,11 @@ jobs:
       - name: Copy NuGet lock file to root
         shell: bash
         run: cp ./__tests__/e2e-test-csproj/packages.lock.json ./packages.lock.json
-      - name: Setup .NET Core 3.1
+      - name: Setup .NET Core 6.0
         id: setup-dotnet
         uses: ./
         with:
-          dotnet-version: 3.1
+          dotnet-version: 6.0
           cache: true
       - name: Verify Cache
         if: steps.setup-dotnet.outputs.cache-hit == 'true'
@@ -528,7 +519,7 @@ jobs:
         run: if [[ -e ${NUGET_PACKAGES} ]]; then exit 0; else exit 1; fi
       - name: Verify dotnet
         shell: pwsh
-        run: __tests__/verify-dotnet.ps1 -Patterns "^3.1"
+        run: __tests__/verify-dotnet.ps1 -Patterns "^6.0"
 
   test-setup-with-cache-extended:
     runs-on: ${{ matrix.operating-system }}
@@ -575,11 +566,11 @@ jobs:
       - name: Clear toolcache
         shell: pwsh
         run: __tests__/clear-toolcache.ps1 ${{ runner.os }}
-      - name: Setup .NET Core 3.1
+      - name: Setup .NET Core 6.0
         id: setup-dotnet
         uses: ./
         with:
-          dotnet-version: 3.1
+          dotnet-version: 6.0
           cache: true
           cache-dependency-path: './__tests__/e2e-test-csproj/packages.lock.json'
       - name: Verify Cache
@@ -588,7 +579,7 @@ jobs:
         run: if [[ -e ${NUGET_PACKAGES} ]]; then exit 0; else exit 1; fi
       - name: Verify dotnet
         shell: pwsh
-        run: __tests__/verify-dotnet.ps1 -Patterns "^3.1"
+        run: __tests__/verify-dotnet.ps1 -Patterns "^6.0"
 
   test-setup-with-cache-dependency-path-extended:
     runs-on: ${{ matrix.operating-system }}
@@ -633,11 +624,11 @@ jobs:
         shell: pwsh
         run: __tests__/clear-toolcache.ps1 ${{ runner.os }}
 
-      - name: Setup dotnet 6.0.401
+      - name: Setup dotnet 8.0.402
         uses: ./
         id: step1
         with:
-          dotnet-version: '6.0.401'
+          dotnet-version: '8.0.402'
 
       - name: Verify value of the dotnet-version output
         shell: pwsh
@@ -660,19 +651,19 @@ jobs:
         shell: pwsh
         run: __tests__/clear-toolcache.ps1 ${{ runner.os }}
 
-      - name: Setup dotnet 6.0.401, 5.0.408, 7.0.100-rc.1.22431.12
+      - name: Setup dotnet 8.0.402, 6.0.401, 7.0.100-rc.1.22431.12
         uses: ./
         id: step2
         with:
           dotnet-version: |
-            7.0.100-rc.1.22431.12
+            8.0.402
             6.0.401
-            5.0.408
+            7.0.100-rc.1.22431.12
 
       - name: Verify value of the dotnet-version output
         shell: pwsh
         run: |
-          $version = "7.0.100-rc.1.22431.12"
+          $version = "8.0.402"
           if (-not ($version -eq '${{steps.step2.outputs.dotnet-version}}')) { throw "Unexpected output value" }
 
   test-proxy:
@@ -703,17 +694,17 @@ jobs:
       - name: Clear toolcache
         shell: pwsh
         run: __tests__/clear-toolcache.ps1 ${{ runner.os }}
-      - name: Setup dotnet 6.0
+      - name: Setup dotnet 8.0
         uses: ./
         with:
-          dotnet-version: 6.0
+          dotnet-version: 8.0
           source-url: https://api.nuget.org/v3/index.json
         env:
           NUGET_AUTH_TOKEN: NOTATOKEN
       - name: Verify dotnet
         shell: pwsh
         run: |
-          __tests__/verify-dotnet.ps1 -Patterns "^6.0" -CheckNugetConfig
+          __tests__/verify-dotnet.ps1 -Patterns "^8.0" -CheckNugetConfig
 
   test-bypass-proxy:
     runs-on: ubuntu-22.04
@@ -726,16 +717,16 @@ jobs:
       - name: Clear toolcache
         shell: pwsh
         run: __tests__/clear-toolcache.ps1 ${{ runner.os }}
-      - name: Setup dotnet 3.1.201
+      - name: Setup dotnet 7.0.410
         uses: ./
         with:
-          dotnet-version: 3.1.201
+          dotnet-version: 7.0.410
           source-url: https://api.nuget.org/v3/index.json
         env:
           NUGET_AUTH_TOKEN: NOTATOKEN
       - name: Verify dotnet
         shell: pwsh
-        run: __tests__/verify-dotnet.ps1 -Patterns "^3.1.201$" -CheckNugetConfig
+        run: __tests__/verify-dotnet.ps1 -Patterns "^7.0.410$" -CheckNugetConfig
 
   test-bypass-proxy-extended:
     runs-on: ubuntu-latest
@@ -765,7 +756,7 @@ jobs:
       fail-fast: false
       matrix:
         operating-system: [ubuntu-22.04, windows-latest, macos-13]
-        lower-version: ['3.1.426']
+        lower-version: ['6.0.427']
         higher-version: ['7.0.203']
     steps:
       - name: Checkout
@@ -788,15 +779,14 @@ jobs:
       - name: Verify dotnet (higher version)
         shell: pwsh
         run: __tests__/verify-dotnet.ps1 -Patterns "^${{ matrix.lower-version }}$", "^${{ matrix.higher-version }}$"
-
   test-sequential-version-installation-extended:
     runs-on: ${{ matrix.operating-system }}
     strategy:
       fail-fast: false
       matrix:
         operating-system: [ubuntu-latest, macos-latest]
-        lower-version: ['6.0.425']
-        higher-version: ['8.0.403']
+        lower-version: ['8.0.403']
+        higher-version: ['9.0.301']
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test-dotnet.yml
+++ b/.github/workflows/test-dotnet.yml
@@ -19,28 +19,7 @@ jobs:
       matrix:
         operating-system:
           [ubuntu-latest, ubuntu-22.04, windows-latest, macos-13, macos-latest]
-        dotnet-version: ['2.1', '2.2', '3.0', '3.1', '5.0', '6.0', '7.0', '8.0']
-        exclude:
-          - dotnet-version: '2.1'
-            operating-system: ubuntu-latest
-          - dotnet-version: '2.2'
-            operating-system: ubuntu-latest
-          - dotnet-version: '3.0'
-            operating-system: ubuntu-latest
-          - dotnet-version: '3.1'
-            operating-system: ubuntu-latest
-          - dotnet-version: '5.0'
-            operating-system: ubuntu-latest
-          - dotnet-version: '2.1'
-            operating-system: macos-latest
-          - dotnet-version: '2.2'
-            operating-system: macos-latest
-          - dotnet-version: '3.0'
-            operating-system: macos-latest
-          - dotnet-version: '3.1'
-            operating-system: macos-latest
-          - dotnet-version: '5.0'
-            operating-system: macos-latest
+        dotnet-version: ['6.0', '7.0', '8.0', '9.0']
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ steps:
 - uses: actions/checkout@v4
 - uses: actions/setup-dotnet@v4
   with:
-    dotnet-version: '3.1.x'
+    dotnet-version: '8.0.x'
 - run: dotnet build <my project>
 ```
 > **Warning**: Unless a concrete version is specified in the [`global.json`](https://learn.microsoft.com/en-us/dotnet/core/tools/global-json) file, **_the latest .NET version installed on the runner (including preinstalled versions) will be used [by default](https://learn.microsoft.com/en-us/dotnet/core/versions/selection#the-sdk-uses-the-latest-installed-version)_**. Please refer to the [documentation](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-software) for the currently preinstalled .NET SDK versions.
@@ -38,8 +38,8 @@ steps:
   uses: actions/setup-dotnet@v4
   with:
     dotnet-version: | 
-      3.1.x
-      5.0.x
+      8.0.x
+      9.0.x
 - run: dotnet build <my project>
 ```
 ## Supported version syntax
@@ -47,9 +47,9 @@ steps:
 The `dotnet-version` input supports following syntax:
 
 - **A.B.C** (e.g 6.0.400, 7.0.100-preview.7.22377.5) - installs exact version of .NET SDK
-- **A.B** or **A.B.x** (e.g. 3.1, 3.1.x) - installs the latest patch version of .NET SDK on the channel `3.1`, including prerelease versions (preview, rc)
-- **A** or **A.x** (e.g. 3, 3.x) - installs the latest minor version of the specified major tag, including prerelease versions (preview, rc)
-- **A.B.Cxx** (e.g. 6.0.4xx) - available since `.NET 5.0` release. Installs the latest version of the specific SDK release, including prerelease versions (preview, rc). 
+- **A.B** or **A.B.x** (e.g. 8.0, 8.0.x) - installs the latest patch version of .NET SDK on the channel `8.0`, including prerelease versions (preview, rc)
+- **A** or **A.x** (e.g. 8, 8.x) - installs the latest minor version of the specified major tag, including prerelease versions (preview, rc)
+- **A.B.Cxx** (e.g. 8.0.4xx) - available since `.NET 5.0` release. Installs the latest version of the specific SDK release, including prerelease versions (preview, rc). 
 
 
 ## Using the `dotnet-quality` input
@@ -62,7 +62,7 @@ steps:
 - uses: actions/checkout@v4
 - uses: actions/setup-dotnet@v4
   with:
-    dotnet-version: '6.0.x'
+    dotnet-version: '8.0.x'
     dotnet-quality: 'preview'
 - run: dotnet build <my project>
 ```
@@ -94,7 +94,7 @@ steps:
 - uses: actions/checkout@v4
 - uses: actions/setup-dotnet@v4
   with:
-    dotnet-version: 6.x
+    dotnet-version: 8.x
     cache: true
 - run: dotnet restore --locked-mode
 ```
@@ -119,7 +119,7 @@ steps:
 - uses: actions/checkout@v4
 - uses: actions/setup-dotnet@v4
   with:
-    dotnet-version: 6.x
+    dotnet-version: 8.x
     cache: true
 - run: dotnet restore --locked-mode
 ```
@@ -133,7 +133,7 @@ steps:
 - uses: actions/checkout@v4
 - uses: actions/setup-dotnet@v4
   with:
-    dotnet-version: 6.x
+    dotnet-version: 8.x
     cache: true
     cache-dependency-path: subdir/packages.lock.json
 - run: dotnet restore --locked-mode
@@ -147,7 +147,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        dotnet: [ '2.1.x', '3.1.x', '5.0.x' ]
+        dotnet: [ '7.0.x', '8.0.x', '9.0.x' ]
     name: Dotnet ${{ matrix.dotnet }} sample
     steps:
       - uses: actions/checkout@v4
@@ -167,7 +167,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        dotnet: [ '2.1.x', '3.1.x', '5.0.x' ]
+        dotnet: [ '7.0.x', '8.0.x', '9.0.x' ]
     name: Dotnet ${{ matrix.dotnet }} sample
     steps:
       - uses: actions/checkout@v4
@@ -189,7 +189,7 @@ steps:
 - uses: actions/checkout@v4
 - uses: actions/setup-dotnet@v4
   with:
-    dotnet-version: '3.1.x'
+    dotnet-version: '8.0.x'
     source-url: https://nuget.pkg.github.com/<owner>/index.json
   env:
     NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
@@ -215,7 +215,7 @@ steps:
 ```yml
 - uses: actions/setup-dotnet@v4
   with:
-    dotnet-version: 3.1.x
+    dotnet-version: 8.0.x
 - name: Publish the package to nuget.org
   run: dotnet nuget push */bin/Release/*.nupkg -k $NUGET_AUTH_TOKEN -s https://api.nuget.org/v3/index.json
   env:
@@ -239,8 +239,8 @@ In case of a single version installation, the `dotnet-version` output contains t
     - uses: actions/setup-dotnet@v4
       id: stepid
       with:
-        dotnet-version: 3.1.422
-    - run: echo '${{ steps.stepid.outputs.dotnet-version }}' # outputs 3.1.422
+        dotnet-version: 8.0.402
+    - run: echo '${{ steps.stepid.outputs.dotnet-version }}' # outputs 8.0.402
 ```
 
 **Multiple version installation**
@@ -252,9 +252,9 @@ In case of a multiple version installation, the `dotnet-version` output contains
       id: stepid
       with:
         dotnet-version: | 
-          3.1.422
-          5.0.408
-    - run: echo '${{ steps.stepid.outputs.dotnet-version }}' # outputs 5.0.408
+          8.0.402
+          9.0.301
+    - run: echo '${{ steps.stepid.outputs.dotnet-version }}' # outputs 9.0.301
 ```
 **Installation from global.json**
 
@@ -265,10 +265,10 @@ When the `dotnet-version` input is used along with the `global-json-file` input,
       id: stepid
       with:
         dotnet-version: | 
-          3.1.422
-          5.0.408
-        global-json-file: "./global.json" # contains version 2.2.207
-    - run: echo '${{ steps.stepid.outputs.dotnet-version }}' # outputs 2.2.207
+          8.0.402
+          9.0.301
+        global-json-file: "./global.json" # contains version 7.0.410
+    - run: echo '${{ steps.stepid.outputs.dotnet-version }}' # outputs 7.0.410
 ```
 
 ### `cache-hit`
@@ -304,7 +304,7 @@ build:
     - uses: actions/checkout@main
     - uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '3.1.x'
+        dotnet-version: '8.0.x'
         cache: true
 ```
 

--- a/__tests__/verify-dotnet.ps1
+++ b/__tests__/verify-dotnet.ps1
@@ -72,6 +72,7 @@ $targetFrameworkVersionMap = @{
   "6.0" = "net6.0";
   "7.0" = "net7.0";
   "8.0" = "net8.0";
+  "9.0" = "net9.0";
  }
 
 foreach ($version in $Versions)


### PR DESCRIPTION
**Description:**

- This pull request eliminates references to older .NET versions from the repository. It also updates the README to accurately reflect the currently available versions and revises the end-to-end (E2E) tests to align with these changes.
- Pull the latest version of installer scripts via `npm run update-installers`.




**Related issue:**
https://github.com/actions/setup-dotnet/issues/645

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.