### PR TITLE
Update to Node.js 24 and modernize async usage

### DIFF
--- a/.github/workflows/basic-validation.yml
+++ b/.github/workflows/basic-validation.yml
@@ -16,4 +16,4 @@ jobs:
     name: Basic validation
     uses: actions/reusable-workflows/.github/workflows/basic-validation.yml@main
     with:
-      node-version: '20'
+      node-version: '24'

--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -16,4 +16,4 @@ jobs:
     name: Check dist/
     uses: actions/reusable-workflows/.github/workflows/check-dist.yml@main
     with:
-      node-version: '20'
+      node-version: '24'

--- a/.licenses/npm/@types/node.dep.yml
+++ b/.licenses/npm/@types/node.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: "@types/node"
-version: 20.11.29
+version: 24.1.0
 type: npm
 summary: TypeScript definitions for node
 homepage: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/node

--- a/.licenses/npm/undici-types.dep.yml
+++ b/.licenses/npm/undici-types.dep.yml
@@ -1,14 +1,16 @@
 ---
 name: undici-types
-version: 5.26.5
+version: 7.8.0
 type: npm
 summary: A stand-alone types package for Undici
 homepage: https://undici.nodejs.org
 license: mit
 licenses:
-- sources: Auto-generated MIT license text
+- sources: LICENSE
   text: |
     MIT License
+
+    Copyright (c) Matteo Collina and Undici contributors
 
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ See [action.yml](action.yml)
 **Basic**:
 ```yaml
 steps:
-- uses: actions/checkout@v4
-- uses: actions/setup-dotnet@v4
+- uses: actions/checkout@v5
+- uses: actions/setup-dotnet@v5
   with:
     dotnet-version: '8.0.x'
 - run: dotnet build <my project>
@@ -33,9 +33,9 @@ steps:
 **Multiple version installation**:
 ```yml
 steps:
-- uses: actions/checkout@v4
+- uses: actions/checkout@v5
 - name: Setup dotnet
-  uses: actions/setup-dotnet@v4
+  uses: actions/setup-dotnet@v5
   with:
     dotnet-version: | 
       8.0.x
@@ -59,8 +59,8 @@ This input sets up the action to install the latest build of the specified quali
 
 ```yml
 steps:
-- uses: actions/checkout@v4
-- uses: actions/setup-dotnet@v4
+- uses: actions/checkout@v5
+- uses: actions/setup-dotnet@v5
   with:
     dotnet-version: '8.0.x'
     dotnet-quality: 'preview'
@@ -74,8 +74,8 @@ steps:
 
 ```yml
 steps:
-- uses: actions/checkout@v4
-- uses: actions/setup-dotnet@v4
+- uses: actions/checkout@v5
+- uses: actions/setup-dotnet@v5
   with:
     global-json-file: csharp/global.json
 - run: dotnet build <my project>
@@ -91,8 +91,8 @@ The action searches for [NuGet Lock files](https://learn.microsoft.com/nuget/con
 
 ```yaml
 steps:
-- uses: actions/checkout@v4
-- uses: actions/setup-dotnet@v4
+- uses: actions/checkout@v5
+- uses: actions/setup-dotnet@v5
   with:
     dotnet-version: 8.x
     cache: true
@@ -116,8 +116,8 @@ steps:
 env:
   NUGET_PACKAGES: ${{ github.workspace }}/.nuget/packages
 steps:
-- uses: actions/checkout@v4
-- uses: actions/setup-dotnet@v4
+- uses: actions/checkout@v5
+- uses: actions/setup-dotnet@v5
   with:
     dotnet-version: 8.x
     cache: true
@@ -130,8 +130,8 @@ steps:
 env:
   NUGET_PACKAGES: ${{ github.workspace }}/.nuget/packages
 steps:
-- uses: actions/checkout@v4
-- uses: actions/setup-dotnet@v4
+- uses: actions/checkout@v5
+- uses: actions/setup-dotnet@v5
   with:
     dotnet-version: 8.x
     cache: true
@@ -150,9 +150,9 @@ jobs:
         dotnet: [ '7.0.x', '8.0.x', '9.0.x' ]
     name: Dotnet ${{ matrix.dotnet }} sample
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup dotnet
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: ${{ matrix.dotnet }}
       - name: Execute dotnet
@@ -170,9 +170,9 @@ jobs:
         dotnet: [ '7.0.x', '8.0.x', '9.0.x' ]
     name: Dotnet ${{ matrix.dotnet }} sample
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup dotnet
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         id: stepid
         with:
           dotnet-version: ${{ matrix.dotnet }}
@@ -186,8 +186,8 @@ jobs:
 ### Github Package Registry (GPR)
 ```yml
 steps:
-- uses: actions/checkout@v4
-- uses: actions/setup-dotnet@v4
+- uses: actions/checkout@v5
+- uses: actions/setup-dotnet@v5
   with:
     dotnet-version: '8.0.x'
     source-url: https://nuget.pkg.github.com/<owner>/index.json
@@ -202,7 +202,7 @@ steps:
 
 ### Azure Artifacts
 ```yml
-- uses: actions/setup-dotnet@v4
+- uses: actions/setup-dotnet@v5
   with:
     source-url: https://pkgs.dev.azure.com/<your-organization>/_packaging/<your-feed-name>/nuget/v3/index.json
   env:
@@ -213,7 +213,7 @@ steps:
 
 ### nuget.org
 ```yml
-- uses: actions/setup-dotnet@v4
+- uses: actions/setup-dotnet@v5
   with:
     dotnet-version: 8.0.x
 - name: Publish the package to nuget.org
@@ -236,7 +236,7 @@ Using the **dotnet-version** output it's possible to get the installed by the ac
 In case of a single version installation, the `dotnet-version` output contains the version that is installed by the action.
 
 ```yaml
-    - uses: actions/setup-dotnet@v4
+    - uses: actions/setup-dotnet@v5
       id: stepid
       with:
         dotnet-version: 8.0.402
@@ -248,7 +248,7 @@ In case of a single version installation, the `dotnet-version` output contains t
 In case of a multiple version installation, the `dotnet-version` output contains the latest version that is installed by the action.
 
 ```yaml
-    - uses: actions/setup-dotnet@v4
+    - uses: actions/setup-dotnet@v5
       id: stepid
       with:
         dotnet-version: | 
@@ -261,7 +261,7 @@ In case of a multiple version installation, the `dotnet-version` output contains
 When the `dotnet-version` input is used along with the `global-json-file` input, the `dotnet-version` output contains the version resolved from the `global.json`.
 
 ```yaml
-    - uses: actions/setup-dotnet@v4
+    - uses: actions/setup-dotnet@v5
       id: stepid
       with:
         dotnet-version: | 
@@ -302,7 +302,7 @@ build:
     NUGET_PACKAGES: ${{ github.workspace }}/.nuget/packages
   steps:
     - uses: actions/checkout@main
-    - uses: actions/setup-dotnet@v4
+    - uses: actions/setup-dotnet@v5
       with:
         dotnet-version: '8.0.x'
         cache: true

--- a/action.yml
+++ b/action.yml
@@ -30,7 +30,7 @@ outputs:
   dotnet-version:
     description: 'Contains the installed by action .NET SDK version for reuse.'
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/setup/index.js'
   post: 'dist/cache-save/index.js'
   post-if: success()

--- a/dist/cache-save/index.js
+++ b/dist/cache-save/index.js
@@ -87721,15 +87721,6 @@ var __importStar = (this && this.__importStar) || function (mod) {
     __setModuleDefault(result, mod);
     return result;
 };
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
@@ -87747,27 +87738,25 @@ process.on('uncaughtException', e => {
     const warningPrefix = '[warning]';
     core.info(`${warningPrefix}${e.message}`);
 });
-function run() {
-    return __awaiter(this, void 0, void 0, function* () {
-        try {
-            if (core.getBooleanInput('cache')) {
-                yield cachePackages();
-            }
+async function run() {
+    try {
+        if (core.getBooleanInput('cache')) {
+            await cachePackages();
         }
-        catch (error) {
-            core.setFailed(error.message);
-        }
-    });
+    }
+    catch (error) {
+        core.setFailed(error.message);
+    }
 }
 exports.run = run;
-const cachePackages = () => __awaiter(void 0, void 0, void 0, function* () {
+const cachePackages = async () => {
     const state = core.getState(constants_1.State.CacheMatchedKey);
     const primaryKey = core.getState(constants_1.State.CachePrimaryKey);
     if (!primaryKey) {
         core.info('Primary key was not generated, not saving cache.');
         return;
     }
-    const { 'global-packages': cachePath } = yield (0, cache_utils_1.getNuGetFolderPath)();
+    const { 'global-packages': cachePath } = await (0, cache_utils_1.getNuGetFolderPath)();
     if (!node_fs_1.default.existsSync(cachePath)) {
         throw new Error(`Cache folder path is retrieved for .NET CLI but doesn't exist on disk: ${cachePath}`);
     }
@@ -87775,12 +87764,12 @@ const cachePackages = () => __awaiter(void 0, void 0, void 0, function* () {
         core.info(`Cache hit occurred on the primary key ${primaryKey}, not saving cache.`);
         return;
     }
-    const cacheId = yield cache.saveCache([cachePath], primaryKey);
+    const cacheId = await cache.saveCache([cachePath], primaryKey);
     if (cacheId == -1) {
         return;
     }
     core.info(`Cache saved with the key: ${primaryKey}`);
-});
+};
 run();
 
 
@@ -87814,15 +87803,6 @@ var __importStar = (this && this.__importStar) || function (mod) {
     __setModuleDefault(result, mod);
     return result;
 };
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.isCacheFeatureAvailable = exports.getNuGetFolderPath = void 0;
 const cache = __importStar(__nccwpck_require__(7799));
@@ -87854,8 +87834,8 @@ const constants_1 = __nccwpck_require__(9042);
  * }
  * ```
  */
-const getNuGetFolderPath = () => __awaiter(void 0, void 0, void 0, function* () {
-    const { stdout, stderr, exitCode } = yield exec.getExecOutput(constants_1.cliCommand, undefined, { ignoreReturnCode: true, silent: true });
+const getNuGetFolderPath = async () => {
+    const { stdout, stderr, exitCode } = await exec.getExecOutput(constants_1.cliCommand, undefined, { ignoreReturnCode: true, silent: true });
     if (exitCode) {
         throw new Error(!stderr.trim()
             ? `The '${constants_1.cliCommand}' command failed with exit code: ${exitCode}`
@@ -87876,7 +87856,7 @@ const getNuGetFolderPath = () => __awaiter(void 0, void 0, void 0, function* () 
         }
     }
     return result;
-});
+};
 exports.getNuGetFolderPath = getNuGetFolderPath;
 function isCacheFeatureAvailable() {
     if (cache.isFeatureAvailable()) {

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -100065,7 +100065,6 @@ function getExistingNugetConfig(processRoot) {
     return defaultConfigName;
 }
 function writeFeedToFile(feedUrl, existingFileLocation, tempFileLocation) {
-    var _a, _b;
     core.info(`dotnet-auth: Finding any source references in ${existingFileLocation}, writing a new temporary configuration file with credentials to ${tempFileLocation}`);
     const sourceKeys = [];
     let owner = core.getInput('owner');
@@ -100087,7 +100086,7 @@ function writeFeedToFile(feedUrl, existingFileLocation, tempFileLocation) {
         if (typeof json.configuration === 'undefined') {
             throw new Error(`The provided NuGet.config seems invalid.`);
         }
-        if ((_b = (_a = json.configuration) === null || _a === void 0 ? void 0 : _a.packageSources) === null || _b === void 0 ? void 0 : _b.add) {
+        if (json.configuration?.packageSources?.add) {
             const packageSources = json.configuration.packageSources.add;
             if (Array.isArray(packageSources)) {
                 packageSources.forEach(source => {
@@ -100224,15 +100223,6 @@ var __importStar = (this && this.__importStar) || function (mod) {
     __setModuleDefault(result, mod);
     return result;
 };
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.restoreCache = void 0;
 const promises_1 = __nccwpck_require__(3977);
@@ -100242,9 +100232,9 @@ const core = __importStar(__nccwpck_require__(2186));
 const glob = __importStar(__nccwpck_require__(8090));
 const cache_utils_1 = __nccwpck_require__(1678);
 const constants_1 = __nccwpck_require__(9042);
-const restoreCache = (cacheDependencyPath) => __awaiter(void 0, void 0, void 0, function* () {
-    const lockFilePath = cacheDependencyPath || (yield findLockFile());
-    const fileHash = yield glob.hashFiles(lockFilePath);
+const restoreCache = async (cacheDependencyPath) => {
+    const lockFilePath = cacheDependencyPath || (await findLockFile());
+    const fileHash = await glob.hashFiles(lockFilePath);
     if (!fileHash) {
         throw new Error('Some specified paths were not resolved, unable to cache dependencies.');
     }
@@ -100252,8 +100242,8 @@ const restoreCache = (cacheDependencyPath) => __awaiter(void 0, void 0, void 0, 
     const primaryKey = `dotnet-cache-${platform}-${fileHash}`;
     core.debug(`primary key is ${primaryKey}`);
     core.saveState(constants_1.State.CachePrimaryKey, primaryKey);
-    const { 'global-packages': cachePath } = yield (0, cache_utils_1.getNuGetFolderPath)();
-    const cacheKey = yield cache.restoreCache([cachePath], primaryKey);
+    const { 'global-packages': cachePath } = await (0, cache_utils_1.getNuGetFolderPath)();
+    const cacheKey = await cache.restoreCache([cachePath], primaryKey);
     core.setOutput(constants_1.Outputs.CacheHit, Boolean(cacheKey));
     if (!cacheKey) {
         core.info('Dotnet cache is not found');
@@ -100261,17 +100251,17 @@ const restoreCache = (cacheDependencyPath) => __awaiter(void 0, void 0, void 0, 
     }
     core.saveState(constants_1.State.CacheMatchedKey, cacheKey);
     core.info(`Cache restored from key: ${cacheKey}`);
-});
+};
 exports.restoreCache = restoreCache;
-const findLockFile = () => __awaiter(void 0, void 0, void 0, function* () {
+const findLockFile = async () => {
     const workspace = process.env.GITHUB_WORKSPACE;
-    const rootContent = yield (0, promises_1.readdir)(workspace);
+    const rootContent = await (0, promises_1.readdir)(workspace);
     const lockFile = constants_1.lockFilePatterns.find(item => rootContent.includes(item));
     if (!lockFile) {
         throw new Error(`Dependencies lock file is not found in ${workspace}. Supported file patterns: ${constants_1.lockFilePatterns.toString()}`);
     }
     return (0, node_path_1.join)(workspace, lockFile);
-});
+};
 
 
 /***/ }),
@@ -100304,15 +100294,6 @@ var __importStar = (this && this.__importStar) || function (mod) {
     __setModuleDefault(result, mod);
     return result;
 };
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.isCacheFeatureAvailable = exports.getNuGetFolderPath = void 0;
 const cache = __importStar(__nccwpck_require__(7799));
@@ -100344,8 +100325,8 @@ const constants_1 = __nccwpck_require__(9042);
  * }
  * ```
  */
-const getNuGetFolderPath = () => __awaiter(void 0, void 0, void 0, function* () {
-    const { stdout, stderr, exitCode } = yield exec.getExecOutput(constants_1.cliCommand, undefined, { ignoreReturnCode: true, silent: true });
+const getNuGetFolderPath = async () => {
+    const { stdout, stderr, exitCode } = await exec.getExecOutput(constants_1.cliCommand, undefined, { ignoreReturnCode: true, silent: true });
     if (exitCode) {
         throw new Error(!stderr.trim()
             ? `The '${constants_1.cliCommand}' command failed with exit code: ${exitCode}`
@@ -100366,7 +100347,7 @@ const getNuGetFolderPath = () => __awaiter(void 0, void 0, void 0, function* () 
         }
     }
     return result;
-});
+};
 exports.getNuGetFolderPath = getNuGetFolderPath;
 function isCacheFeatureAvailable() {
     if (cache.isFeatureAvailable()) {
@@ -100451,15 +100432,6 @@ var __importStar = (this && this.__importStar) || function (mod) {
     __setModuleDefault(result, mod);
     return result;
 };
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
@@ -100478,29 +100450,28 @@ const utils_1 = __nccwpck_require__(1314);
 const QUALITY_INPUT_MINIMAL_MAJOR_TAG = 6;
 const LATEST_PATCH_SYNTAX_MINIMAL_MAJOR_TAG = 5;
 class DotnetVersionResolver {
+    inputVersion;
+    resolvedArgument;
     constructor(version) {
         this.inputVersion = version.trim();
         this.resolvedArgument = { type: '', value: '', qualityFlag: false };
     }
-    resolveVersionInput() {
-        return __awaiter(this, void 0, void 0, function* () {
-            if (!semver_1.default.validRange(this.inputVersion) && !this.isLatestPatchSyntax()) {
-                throw new Error(`The 'dotnet-version' was supplied in invalid format: ${this.inputVersion}! Supported syntax: A.B.C, A.B, A.B.x, A, A.x, A.B.Cxx`);
-            }
-            if (semver_1.default.valid(this.inputVersion)) {
-                this.createVersionArgument();
-            }
-            else {
-                yield this.createChannelArgument();
-            }
-        });
+    async resolveVersionInput() {
+        if (!semver_1.default.validRange(this.inputVersion) && !this.isLatestPatchSyntax()) {
+            throw new Error(`The 'dotnet-version' was supplied in invalid format: ${this.inputVersion}! Supported syntax: A.B.C, A.B, A.B.x, A, A.x, A.B.Cxx`);
+        }
+        if (semver_1.default.valid(this.inputVersion)) {
+            this.createVersionArgument();
+        }
+        else {
+            await this.createChannelArgument();
+        }
     }
     isNumericTag(versionTag) {
         return /^\d+$/.test(versionTag);
     }
     isLatestPatchSyntax() {
-        var _a, _b;
-        const majorTag = (_b = (_a = this.inputVersion.match(/^(?<majorTag>\d+)\.\d+\.\d{1}x{2}$/)) === null || _a === void 0 ? void 0 : _a.groups) === null || _b === void 0 ? void 0 : _b.majorTag;
+        const majorTag = this.inputVersion.match(/^(?<majorTag>\d+)\.\d+\.\d{1}x{2}$/)?.groups?.majorTag;
         if (majorTag &&
             parseInt(majorTag) < LATEST_PATCH_SYNTAX_MINIMAL_MAJOR_TAG) {
             throw new Error(`The 'dotnet-version' was supplied in invalid format: ${this.inputVersion}! The A.B.Cxx syntax is available since the .NET 5.0 release.`);
@@ -100511,70 +100482,65 @@ class DotnetVersionResolver {
         this.resolvedArgument.type = 'version';
         this.resolvedArgument.value = this.inputVersion;
     }
-    createChannelArgument() {
-        return __awaiter(this, void 0, void 0, function* () {
-            this.resolvedArgument.type = 'channel';
-            const [major, minor] = this.inputVersion.split('.');
-            if (this.isLatestPatchSyntax()) {
-                this.resolvedArgument.value = this.inputVersion;
-            }
-            else if (this.isNumericTag(major) && this.isNumericTag(minor)) {
-                this.resolvedArgument.value = `${major}.${minor}`;
-            }
-            else if (this.isNumericTag(major)) {
-                this.resolvedArgument.value = yield this.getLatestByMajorTag(major);
-            }
-            else {
-                // If "dotnet-version" is specified as *, x or X resolve latest version of .NET explicitly from LTS channel. The version argument will default to "latest" by install-dotnet script.
-                this.resolvedArgument.value = 'LTS';
-            }
-            this.resolvedArgument.qualityFlag =
-                parseInt(major) >= QUALITY_INPUT_MINIMAL_MAJOR_TAG ? true : false;
-        });
+    async createChannelArgument() {
+        this.resolvedArgument.type = 'channel';
+        const [major, minor] = this.inputVersion.split('.');
+        if (this.isLatestPatchSyntax()) {
+            this.resolvedArgument.value = this.inputVersion;
+        }
+        else if (this.isNumericTag(major) && this.isNumericTag(minor)) {
+            this.resolvedArgument.value = `${major}.${minor}`;
+        }
+        else if (this.isNumericTag(major)) {
+            this.resolvedArgument.value = await this.getLatestByMajorTag(major);
+        }
+        else {
+            // If "dotnet-version" is specified as *, x or X resolve latest version of .NET explicitly from LTS channel. The version argument will default to "latest" by install-dotnet script.
+            this.resolvedArgument.value = 'LTS';
+        }
+        this.resolvedArgument.qualityFlag =
+            parseInt(major) >= QUALITY_INPUT_MINIMAL_MAJOR_TAG ? true : false;
     }
-    createDotnetVersion() {
-        return __awaiter(this, void 0, void 0, function* () {
-            yield this.resolveVersionInput();
-            if (!this.resolvedArgument.type) {
-                return this.resolvedArgument;
-            }
-            if (utils_1.IS_WINDOWS) {
-                this.resolvedArgument.type =
-                    this.resolvedArgument.type === 'channel' ? '-Channel' : '-Version';
-            }
-            else {
-                this.resolvedArgument.type =
-                    this.resolvedArgument.type === 'channel' ? '--channel' : '--version';
-            }
+    async createDotnetVersion() {
+        await this.resolveVersionInput();
+        if (!this.resolvedArgument.type) {
             return this.resolvedArgument;
-        });
+        }
+        if (utils_1.IS_WINDOWS) {
+            this.resolvedArgument.type =
+                this.resolvedArgument.type === 'channel' ? '-Channel' : '-Version';
+        }
+        else {
+            this.resolvedArgument.type =
+                this.resolvedArgument.type === 'channel' ? '--channel' : '--version';
+        }
+        return this.resolvedArgument;
     }
-    getLatestByMajorTag(majorTag) {
-        return __awaiter(this, void 0, void 0, function* () {
-            const httpClient = new hc.HttpClient('actions/setup-dotnet', [], {
-                allowRetries: true,
-                maxRetries: 3
-            });
-            const response = yield httpClient.getJson(DotnetVersionResolver.DotnetCoreIndexUrl);
-            const result = response.result || {};
-            const releasesInfo = result['releases-index'];
-            const releaseInfo = releasesInfo.find(info => {
-                const sdkParts = info['channel-version'].split('.');
-                return sdkParts[0] === majorTag;
-            });
-            if (!releaseInfo) {
-                throw new Error(`Could not find info for version with major tag: "${majorTag}" at ${DotnetVersionResolver.DotnetCoreIndexUrl}`);
-            }
-            return releaseInfo['channel-version'];
+    async getLatestByMajorTag(majorTag) {
+        const httpClient = new hc.HttpClient('actions/setup-dotnet', [], {
+            allowRetries: true,
+            maxRetries: 3
         });
+        const response = await httpClient.getJson(DotnetVersionResolver.DotnetCoreIndexUrl);
+        const result = response.result || {};
+        const releasesInfo = result['releases-index'];
+        const releaseInfo = releasesInfo.find(info => {
+            const sdkParts = info['channel-version'].split('.');
+            return sdkParts[0] === majorTag;
+        });
+        if (!releaseInfo) {
+            throw new Error(`Could not find info for version with major tag: "${majorTag}" at ${DotnetVersionResolver.DotnetCoreIndexUrl}`);
+        }
+        return releaseInfo['channel-version'];
     }
+    static DotnetCoreIndexUrl = 'https://builds.dotnet.microsoft.com/dotnet/release-metadata/releases-index.json';
 }
 exports.DotnetVersionResolver = DotnetVersionResolver;
-DotnetVersionResolver.DotnetCoreIndexUrl = 'https://builds.dotnet.microsoft.com/dotnet/release-metadata/releases-index.json';
 class DotnetInstallScript {
+    scriptName = utils_1.IS_WINDOWS ? 'install-dotnet.ps1' : 'install-dotnet.sh';
+    escapedScript;
+    scriptArguments = [];
     constructor() {
-        this.scriptName = utils_1.IS_WINDOWS ? 'install-dotnet.ps1' : 'install-dotnet.sh';
-        this.scriptArguments = [];
         this.escapedScript = path_1.default
             .join(__dirname, '..', '..', 'externals', this.scriptName)
             .replace(/'/g, "''");
@@ -100606,13 +100572,11 @@ class DotnetInstallScript {
     setupScriptBash() {
         (0, fs_1.chmodSync)(this.escapedScript, '777');
     }
-    getScriptPath() {
-        return __awaiter(this, void 0, void 0, function* () {
-            if (utils_1.IS_WINDOWS) {
-                return (yield io.which('pwsh', false)) || io.which('powershell', true);
-            }
-            return io.which(this.escapedScript, true);
-        });
+    async getScriptPath() {
+        if (utils_1.IS_WINDOWS) {
+            return (await io.which('pwsh', false)) || io.which('powershell', true);
+        }
+        return io.which(this.escapedScript, true);
     }
     useArguments(...args) {
         this.scriptArguments.push(...args);
@@ -100631,18 +100595,24 @@ class DotnetInstallScript {
         }
         return this;
     }
-    execute() {
-        return __awaiter(this, void 0, void 0, function* () {
-            const getExecOutputOptions = {
-                ignoreReturnCode: true,
-                env: process.env
-            };
-            return exec.getExecOutput(`"${yield this.getScriptPath()}"`, this.scriptArguments, getExecOutputOptions);
-        });
+    async execute() {
+        const getExecOutputOptions = {
+            ignoreReturnCode: true,
+            env: process.env
+        };
+        return exec.getExecOutput(`"${await this.getScriptPath()}"`, this.scriptArguments, getExecOutputOptions);
     }
 }
 exports.DotnetInstallScript = DotnetInstallScript;
 class DotnetInstallDir {
+    static default = {
+        linux: '/usr/share/dotnet',
+        mac: path_1.default.join(process.env['HOME'] + '', '.dotnet'),
+        windows: path_1.default.join(process.env['PROGRAMFILES'] + '', 'dotnet')
+    };
+    static dirPath = process.env['DOTNET_INSTALL_DIR']
+        ? DotnetInstallDir.convertInstallPathToAbsolute(process.env['DOTNET_INSTALL_DIR'])
+        : DotnetInstallDir.default[utils_1.PLATFORM];
     static convertInstallPathToAbsolute(installDir) {
         if (path_1.default.isAbsolute(installDir))
             return path_1.default.normalize(installDir);
@@ -100660,57 +100630,52 @@ class DotnetInstallDir {
     }
 }
 exports.DotnetInstallDir = DotnetInstallDir;
-DotnetInstallDir.default = {
-    linux: '/usr/share/dotnet',
-    mac: path_1.default.join(process.env['HOME'] + '', '.dotnet'),
-    windows: path_1.default.join(process.env['PROGRAMFILES'] + '', 'dotnet')
-};
-DotnetInstallDir.dirPath = process.env['DOTNET_INSTALL_DIR']
-    ? DotnetInstallDir.convertInstallPathToAbsolute(process.env['DOTNET_INSTALL_DIR'])
-    : DotnetInstallDir.default[utils_1.PLATFORM];
 class DotnetCoreInstaller {
+    version;
+    quality;
+    static {
+        DotnetInstallDir.setEnvironmentVariable();
+    }
     constructor(version, quality) {
         this.version = version;
         this.quality = quality;
     }
-    installDotnet() {
-        return __awaiter(this, void 0, void 0, function* () {
-            const versionResolver = new DotnetVersionResolver(this.version);
-            const dotnetVersion = yield versionResolver.createDotnetVersion();
+    async installDotnet() {
+        const versionResolver = new DotnetVersionResolver(this.version);
+        const dotnetVersion = await versionResolver.createDotnetVersion();
+        /**
+         * Install dotnet runitme first in order to get
+         * the latest stable version of dotnet CLI
+         */
+        const runtimeInstallOutput = await new DotnetInstallScript()
+            // If dotnet CLI is already installed - avoid overwriting it
+            .useArguments(utils_1.IS_WINDOWS ? '-SkipNonVersionedFiles' : '--skip-non-versioned-files')
+            // Install only runtime + CLI
+            .useArguments(utils_1.IS_WINDOWS ? '-Runtime' : '--runtime', 'dotnet')
+            // Use latest stable version
+            .useArguments(utils_1.IS_WINDOWS ? '-Channel' : '--channel', 'LTS')
+            .execute();
+        if (runtimeInstallOutput.exitCode) {
             /**
-             * Install dotnet runitme first in order to get
-             * the latest stable version of dotnet CLI
+             * dotnetInstallScript will install CLI and runtime even if previous script haven't succeded,
+             * so at this point it's too early to throw an error
              */
-            const runtimeInstallOutput = yield new DotnetInstallScript()
-                // If dotnet CLI is already installed - avoid overwriting it
-                .useArguments(utils_1.IS_WINDOWS ? '-SkipNonVersionedFiles' : '--skip-non-versioned-files')
-                // Install only runtime + CLI
-                .useArguments(utils_1.IS_WINDOWS ? '-Runtime' : '--runtime', 'dotnet')
-                // Use latest stable version
-                .useArguments(utils_1.IS_WINDOWS ? '-Channel' : '--channel', 'LTS')
-                .execute();
-            if (runtimeInstallOutput.exitCode) {
-                /**
-                 * dotnetInstallScript will install CLI and runtime even if previous script haven't succeded,
-                 * so at this point it's too early to throw an error
-                 */
-                core.warning(`Failed to install dotnet runtime + cli, exit code: ${runtimeInstallOutput.exitCode}. ${runtimeInstallOutput.stderr}`);
-            }
-            /**
-             * Install dotnet over the latest version of
-             * dotnet CLI
-             */
-            const dotnetInstallOutput = yield new DotnetInstallScript()
-                // Don't overwrite CLI because it should be already installed
-                .useArguments(utils_1.IS_WINDOWS ? '-SkipNonVersionedFiles' : '--skip-non-versioned-files')
-                // Use version provided by user
-                .useVersion(dotnetVersion, this.quality)
-                .execute();
-            if (dotnetInstallOutput.exitCode) {
-                throw new Error(`Failed to install dotnet, exit code: ${dotnetInstallOutput.exitCode}. ${dotnetInstallOutput.stderr}`);
-            }
-            return this.parseInstalledVersion(dotnetInstallOutput.stdout);
-        });
+            core.warning(`Failed to install dotnet runtime + cli, exit code: ${runtimeInstallOutput.exitCode}. ${runtimeInstallOutput.stderr}`);
+        }
+        /**
+         * Install dotnet over the latest version of
+         * dotnet CLI
+         */
+        const dotnetInstallOutput = await new DotnetInstallScript()
+            // Don't overwrite CLI because it should be already installed
+            .useArguments(utils_1.IS_WINDOWS ? '-SkipNonVersionedFiles' : '--skip-non-versioned-files')
+            // Use version provided by user
+            .useVersion(dotnetVersion, this.quality)
+            .execute();
+        if (dotnetInstallOutput.exitCode) {
+            throw new Error(`Failed to install dotnet, exit code: ${dotnetInstallOutput.exitCode}. ${dotnetInstallOutput.stderr}`);
+        }
+        return this.parseInstalledVersion(dotnetInstallOutput.stdout);
     }
     parseInstalledVersion(stdout) {
         const regex = /(?<version>\d+\.\d+\.\d+[a-z0-9._-]*)/gm;
@@ -100723,9 +100688,6 @@ class DotnetCoreInstaller {
     }
 }
 exports.DotnetCoreInstaller = DotnetCoreInstaller;
-(() => {
-    DotnetInstallDir.setEnvironmentVariable();
-})();
 
 
 /***/ }),
@@ -100758,15 +100720,6 @@ var __importStar = (this && this.__importStar) || function (mod) {
     __setModuleDefault(result, mod);
     return result;
 };
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
@@ -100789,70 +100742,68 @@ const qualityOptions = [
     'preview',
     'ga'
 ];
-function run() {
-    return __awaiter(this, void 0, void 0, function* () {
-        try {
-            //
-            // dotnet-version is optional, but needs to be provided for most use cases.
-            // If supplied, install / use from the tool cache.
-            // global-version-file may be specified to point to a specific global.json
-            // and will be used to install an additional version.
-            // If not supplied, look for version in ./global.json.
-            // If a valid version still can't be identified, nothing will be installed.
-            // Proxy, auth, (etc) are still set up, even if no version is identified
-            //
-            const versions = core.getMultilineInput('dotnet-version');
-            const installedDotnetVersions = [];
-            const globalJsonFileInput = core.getInput('global-json-file');
-            if (globalJsonFileInput) {
-                const globalJsonPath = path_1.default.resolve(process.cwd(), globalJsonFileInput);
-                if (!fs.existsSync(globalJsonPath)) {
-                    throw new Error(`The specified global.json file '${globalJsonFileInput}' does not exist`);
-                }
+async function run() {
+    try {
+        //
+        // dotnet-version is optional, but needs to be provided for most use cases.
+        // If supplied, install / use from the tool cache.
+        // global-version-file may be specified to point to a specific global.json
+        // and will be used to install an additional version.
+        // If not supplied, look for version in ./global.json.
+        // If a valid version still can't be identified, nothing will be installed.
+        // Proxy, auth, (etc) are still set up, even if no version is identified
+        //
+        const versions = core.getMultilineInput('dotnet-version');
+        const installedDotnetVersions = [];
+        const globalJsonFileInput = core.getInput('global-json-file');
+        if (globalJsonFileInput) {
+            const globalJsonPath = path_1.default.resolve(process.cwd(), globalJsonFileInput);
+            if (!fs.existsSync(globalJsonPath)) {
+                throw new Error(`The specified global.json file '${globalJsonFileInput}' does not exist`);
+            }
+            versions.push(getVersionFromGlobalJson(globalJsonPath));
+        }
+        if (!versions.length) {
+            // Try to fall back to global.json
+            core.debug('No version found, trying to find version from global.json');
+            const globalJsonPath = path_1.default.join(process.cwd(), 'global.json');
+            if (fs.existsSync(globalJsonPath)) {
                 versions.push(getVersionFromGlobalJson(globalJsonPath));
             }
-            if (!versions.length) {
-                // Try to fall back to global.json
-                core.debug('No version found, trying to find version from global.json');
-                const globalJsonPath = path_1.default.join(process.cwd(), 'global.json');
-                if (fs.existsSync(globalJsonPath)) {
-                    versions.push(getVersionFromGlobalJson(globalJsonPath));
-                }
-                else {
-                    core.info(`The global.json wasn't found in the root directory. No .NET version will be installed.`);
-                }
+            else {
+                core.info(`The global.json wasn't found in the root directory. No .NET version will be installed.`);
             }
-            if (versions.length) {
-                const quality = core.getInput('dotnet-quality');
-                if (quality && !qualityOptions.includes(quality)) {
-                    throw new Error(`Value '${quality}' is not supported for the 'dotnet-quality' option. Supported values are: daily, signed, validated, preview, ga.`);
-                }
-                let dotnetInstaller;
-                const uniqueVersions = new Set(versions);
-                for (const version of uniqueVersions) {
-                    dotnetInstaller = new installer_1.DotnetCoreInstaller(version, quality);
-                    const installedVersion = yield dotnetInstaller.installDotnet();
-                    installedDotnetVersions.push(installedVersion);
-                }
-                installer_1.DotnetInstallDir.addToPath();
-            }
-            const sourceUrl = core.getInput('source-url');
-            const configFile = core.getInput('config-file');
-            if (sourceUrl) {
-                auth.configAuthentication(sourceUrl, configFile);
-            }
-            outputInstalledVersion(installedDotnetVersions, globalJsonFileInput);
-            if (core.getBooleanInput('cache') && (0, cache_utils_1.isCacheFeatureAvailable)()) {
-                const cacheDependencyPath = core.getInput('cache-dependency-path');
-                yield (0, cache_restore_1.restoreCache)(cacheDependencyPath);
-            }
-            const matchersPath = path_1.default.join(__dirname, '..', '..', '.github');
-            core.info(`##[add-matcher]${path_1.default.join(matchersPath, 'csc.json')}`);
         }
-        catch (error) {
-            core.setFailed(error.message);
+        if (versions.length) {
+            const quality = core.getInput('dotnet-quality');
+            if (quality && !qualityOptions.includes(quality)) {
+                throw new Error(`Value '${quality}' is not supported for the 'dotnet-quality' option. Supported values are: daily, signed, validated, preview, ga.`);
+            }
+            let dotnetInstaller;
+            const uniqueVersions = new Set(versions);
+            for (const version of uniqueVersions) {
+                dotnetInstaller = new installer_1.DotnetCoreInstaller(version, quality);
+                const installedVersion = await dotnetInstaller.installDotnet();
+                installedDotnetVersions.push(installedVersion);
+            }
+            installer_1.DotnetInstallDir.addToPath();
         }
-    });
+        const sourceUrl = core.getInput('source-url');
+        const configFile = core.getInput('config-file');
+        if (sourceUrl) {
+            auth.configAuthentication(sourceUrl, configFile);
+        }
+        outputInstalledVersion(installedDotnetVersions, globalJsonFileInput);
+        if (core.getBooleanInput('cache') && (0, cache_utils_1.isCacheFeatureAvailable)()) {
+            const cacheDependencyPath = core.getInput('cache-dependency-path');
+            await (0, cache_restore_1.restoreCache)(cacheDependencyPath);
+        }
+        const matchersPath = path_1.default.join(__dirname, '..', '..', '.github');
+        core.info(`##[add-matcher]${path_1.default.join(matchersPath, 'csc.json')}`);
+    }
+    catch (error) {
+        core.setFailed(error.message);
+    }
 }
 exports.run = run;
 function getVersionFromGlobalJson(globalJsonPath) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "setup-dotnet",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "setup-dotnet",
-      "version": "4.0.0",
+      "version": "5.0.0",
       "license": "MIT",
       "dependencies": {
         "@actions/cache": "^4.0.3",
@@ -41,7 +41,7 @@
         "wget-improved": "^3.2.1"
       },
       "engines": {
-        "node": ">=24"
+        "node": ">=24.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
       },
       "devDependencies": {
         "@types/jest": "^29.5.12",
-        "@types/node": "^20.11.29",
+        "@types/node": "^24.1.0",
         "@types/semver": "^7.5.8",
         "@typescript-eslint/eslint-plugin": "^7.3.0",
         "@typescript-eslint/parser": "^7.3.0",
@@ -39,6 +39,9 @@
         "ts-jest": "^29.1.2",
         "typescript": "^5.4.2",
         "wget-improved": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=24"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -1779,11 +1782,12 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.11.29",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.29.tgz",
-      "integrity": "sha512-P99thMkD/1YkCvAtOd6/zGedKNA0p2fj4ZpjCzcNiSCBWgm3cNRTBfa/qjFnsKkkojxu4vVLtWpesnZ9+ap+gA==",
+      "version": "24.1.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.1.0.tgz",
+      "integrity": "sha512-ut5FthK5moxFKH2T1CUOC6ctR67rQRvvHdFLCD2Ql6KXmMuCrjsSsRI9UsLCm9M18BMwClv4pn327UvB7eeO1w==",
+      "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~7.8.0"
       }
     },
     "node_modules/@types/node-fetch": {
@@ -5986,9 +5990,10 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
+      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
+      "license": "MIT"
     },
     "node_modules/universal-user-agent": {
       "version": "6.0.1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "description": "setup dotnet action",
   "main": "dist/setup/index.js",
-      "engines": {
+  "engines": {
     "node": ">=24"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "setup-dotnet",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "private": true,
   "description": "setup dotnet action",
   "main": "dist/setup/index.js",
   "engines": {
-    "node": ">=24"
+    "node": ">=24.0.0"
   },
   "scripts": {
     "build": "ncc build -o dist/setup src/setup-dotnet.ts && ncc build -o dist/cache-save src/cache-save.ts",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "private": true,
   "description": "setup dotnet action",
   "main": "dist/setup/index.js",
+      "engines": {
+    "node": ">=24"
+  },
   "scripts": {
     "build": "ncc build -o dist/setup src/setup-dotnet.ts && ncc build -o dist/cache-save src/cache-save.ts",
     "format": "prettier --no-error-on-unmatched-pattern --config ./.prettierrc.js --write \"**/*.{ts,yml,yaml}\"",
@@ -39,7 +42,7 @@
   },
   "devDependencies": {
     "@types/jest": "^29.5.12",
-    "@types/node": "^20.11.29",
+    "@types/node": "^24.1.0",
     "@types/semver": "^7.5.8",
     "@typescript-eslint/eslint-plugin": "^7.3.0",
     "@typescript-eslint/parser": "^7.3.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,10 +2,10 @@
   "compilerOptions": {
     /* Basic Options */
     // "incremental": true,                   /* Enable incremental compilation */
-    "target": "es6",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
+    "target": "ES2022",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
     "lib": [
-      "es6"
+      "ES2022"
     ],
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */


### PR DESCRIPTION
Bump Node.js version to 24 in workflows, action metadata, and engines. Update TypeScript target to ES2022 and use native async/await instead of __awaiter in compiled JS. Upgrade @types/node to 24.1.0 and update undici-types. Remove legacy async helpers and refactor code for improved readability and compatibility with modern Node.js.

**Description:**
Describe your changes.

**Related issue:**
Add link to the related issue.

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.