### PR TITLE
Fix regex pattern in csc.json

### DIFF
--- a/.github/csc.json
+++ b/.github/csc.json
@@ -4,7 +4,7 @@
             "owner": "csc",
             "pattern": [
                 {
-                    "regexp": "^([^\\s].*)\\((\\d+)(?:,\\d+|,\\d+,\\d+)?\\):\\s+(error|warning)\\s+([a-zA-Z]+(?<!MSB)\\d+):\\s*(.*?)\\s+\\[(.*?)\\]$",
+                    "regexp": "^(.*)\\((\\d+)(?:,\\d+|,\\d+,\\d+)?\\):\\s+(error|warning)\\s+([a-zA-Z]+(?<!MSB)\\d+):\\s*(.*?)\\s+\\[(.*?)\\]$",
                     "file": 1,
                     "line": 2,
                     "severity": 3,


### PR DESCRIPTION
**Description:**
We use basic dotnet 10, and our build errors start with only spaces.

**Related issue:**
None.

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.