### PR TITLE
Fix global.json creation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,8 @@ jobs:
         with:
           dotnet-version: ${{ matrix.dotnet }}
       - name: Create temporary global.json
-        run: echo '{"sdk":{"version": "${{ steps.stepid.outputs.dotnet-version }}"}}' > ./global.json
+        run: |
+          echo '{"sdk":{"version": "${{ steps.stepid.outputs.dotnet-version }}"}}' > ./global.json
       - name: Execute dotnet
         run: dotnet build <my project>
 ```


### PR DESCRIPTION
Currently line that adds additional JSON to `global.json` fails GitHub workflow with:
```
Invalid workflow file: .github/workflows/build.yaml#L146
You have an error in your yaml syntax on line 146
```

Copilot explanation:

> YAML Parsing and Special Characters
> Single-line syntax: When you use run: followed by content on the same line, YAML parses it as a plain scalar. The > character in your command is interpreted as part of the YAML syntax (specifically, a folded scalar indicator) rather than a shell redirection operator.
> Multi-line block scalar (|): The pipe | tells YAML to treat everything that follows as a literal block scalar, preserving newlines and special characters exactly as written. The > is now correctly interpreted by the shell as a redirection operator.