### PR TITLE
Add cache-write input for read-only cache mode

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,10 @@ inputs:
   cache-dependency-path:
     description: 'Used to specify the path to a dependency file: packages.lock.json. Supports wildcards or a list of file names for caching multiple dependencies.'
     required: false
+  cache-write:
+    description: 'Whether to save the cache at the end of the workflow. Set to false for cache read-only mode, useful for preventing cache poisoning from untrusted PR builds.'
+    required: false
+    default: true
   workloads:
     description: 'Optional SDK workloads to install for additional platform support. Examples: wasm-tools, maui, aspire.'
     required: false

--- a/dist/cache-save/index.js
+++ b/dist/cache-save/index.js
@@ -44650,6 +44650,11 @@ process.on('uncaughtException', e => {
 });
 async function run() {
     try {
+        const cacheWriteEnabled = core.getInput('cache-write');
+        if (cacheWriteEnabled === 'false') {
+            core.info('Cache write is disabled (read-only mode). Skipping cache save.');
+            return;
+        }
         if (core.getBooleanInput('cache')) {
             await cachePackages();
         }

--- a/src/cache-save.ts
+++ b/src/cache-save.ts
@@ -14,6 +14,12 @@ process.on('uncaughtException', e => {
 
 export async function run() {
   try {
+    const cacheWriteEnabled = core.getInput('cache-write');
+    if (cacheWriteEnabled === 'false') {
+      core.info('Cache write is disabled (read-only mode). Skipping cache save.');
+      return;
+    }
+
     if (core.getBooleanInput('cache')) {
       await cachePackages();
     }


### PR DESCRIPTION
When `cache: true` is set, this action restores and saves the NuGet global-packages cache. For PR workflows there's no way to do restore-only — a malicious PR can write to the cache and have it affect later trusted runs.

This adds a `cache-write` input (defaults to `true`, backward compatible). When `false`, the post-step save is skipped.

**Usage:**
```yaml
- uses: actions/setup-dotnet@v5
  with:
    dotnet-version: 8.x
    cache: true
    cache-write: ${{ github.event_name != 'pull_request' }}
```

**What changed:**
- `action.yml` — new `cache-write` input
- `src/cache-save.ts` — early return when `cache-write` is `false`
- `dist/` — rebuilt

Same change going into setup-node, setup-python, setup-go, setup-java.