### PR TITLE
Expand the CSC problem matcher to light up more errors on GitHub.

### DIFF
--- a/.github/csc.json
+++ b/.github/csc.json
@@ -4,13 +4,14 @@
             "owner": "csc",
             "pattern": [
                 {
-                    "regexp": "^([^\\s].*)\\((\\d+)(?:,\\d+|,\\d+,\\d+)?\\):\\s+(error|warning)\\s+([a-zA-Z]+(?<!MSB)\\d+):\\s*(.*?)\\s+\\[(.*?)\\]$",
+                    "regexp": "^\\s*(?:\\d+>\\s*)?([^\\s].*)\\((\\d+)(?:,(\\d+))?(?:,\\d+)*\\):\\s+(error|warning)\\s+([a-zA-Z]+(?<!MSB)\\d*):\\s*(.*?)\\s+\\[(.*?)\\]$",
                     "file": 1,
                     "line": 2,
-                    "severity": 3,
-                    "code": 4,
-                    "message": 5,
-                    "fromPath": 6
+                    "column": 3,
+                    "severity": 4,
+                    "code": 5,
+                    "message": 6,
+                    "fromPath": 7
                 }
             ]
         }

--- a/__tests__/csc.test.ts
+++ b/__tests__/csc.test.ts
@@ -1,45 +1,96 @@
 import cscFile from '../.github/csc.json';
 describe('csc tests', () => {
-  test('regular expression in csc.json is valid', async () => {
-    const regexPattern = cscFile['problemMatcher'][0]['pattern'][0]['regexp'];
-    const regexResultsMap = cscFile['problemMatcher'][0]['pattern'][0];
+  const regexPattern = cscFile['problemMatcher'][0]['pattern'][0]['regexp'];
+  const regexResultsMap = cscFile['problemMatcher'][0]['pattern'][0];
+  const regex = new RegExp(regexPattern);
 
-    const regex = new RegExp(regexPattern);
-
-    const stringsToMatch = [
-      'Program.cs(10,79): error CS1002: ; expected [/Users/zacharyeisinger/Documents/repo/setup-dotnet/__tests__/sample-broken-csproj/sample.csproj]',
-      "S:\\Msbuild\\src\\Build\\Evaluation\\ExpressionShredder.cs(33,7): error CS1003: Syntax error, ',' expected [S:\\msbuild\\src\\Build\\Microsoft.Build.csproj > Properties:prop]"
-    ];
-    // Expected results are calculated according to the csc matcher located in csc.json file
-    const expectedResults = [
-      {
+  const testCases: Array<{input: string; results: Record<string, string>}> = [
+    {
+      input:
+        'Program.cs(10,79): error CS1002: ; expected [/Users/zacharyeisinger/Documents/repo/setup-dotnet/__tests__/sample-broken-csproj/sample.csproj]',
+      results: {
         file: 'Program.cs',
         line: '10',
+        column: '79',
         severity: 'error',
         code: 'CS1002',
         message: '; expected',
         fromPath:
           '/Users/zacharyeisinger/Documents/repo/setup-dotnet/__tests__/sample-broken-csproj/sample.csproj'
-      },
-      {
+      }
+    },
+    {
+      input:
+        "S:\\Msbuild\\src\\Build\\Evaluation\\ExpressionShredder.cs(33,7): error CS1003: Syntax error, ',' expected [S:\\msbuild\\src\\Build\\Microsoft.Build.csproj > Properties:prop]",
+      results: {
         file: 'S:\\Msbuild\\src\\Build\\Evaluation\\ExpressionShredder.cs',
         line: '33',
+        column: '7',
         severity: 'error',
         code: 'CS1003',
         message: "Syntax error, ',' expected",
         fromPath:
           'S:\\msbuild\\src\\Build\\Microsoft.Build.csproj > Properties:prop'
       }
-    ];
+    },
+    {
+      // `dotnet format` style error
+      input:
+        'C:\\actions-runner\\_work\\Some\\Folder\\SomeFile.cs(222,8): error WHITESPACE: Fix whitespace formatting. Delete 1 characters. [C:\\actions-runner\\_work\\Some\\Folder\\SomeProject.csproj]',
+      results: {
+        file: 'C:\\actions-runner\\_work\\Some\\Folder\\SomeFile.cs',
+        line: '222',
+        column: '8',
+        severity: 'error',
+        code: 'WHITESPACE',
+        message: 'Fix whitespace formatting. Delete 1 characters.',
+        fromPath: 'C:\\actions-runner\\_work\\Some\\Folder\\SomeProject.csproj'
+      }
+    },
+    {
+      // CSC error with whitespace prefix
+      input:
+        '  /Volumes/Code/ghe_actions-2.301.1/Some/Folder/SomeFile.cs(10,8): error CS1014: A get or set accessor expected [/Volumes/Code/ghe_actions-2.301.1/Some/Folder/SomeProject.csproj]',
+      results: {
+        file: '/Volumes/Code/ghe_actions-2.301.1/Some/Folder/SomeFile.cs',
+        line: '10',
+        column: '8',
+        severity: 'error',
+        code: 'CS1014',
+        message: 'A get or set accessor expected',
+        fromPath:
+          '/Volumes/Code/ghe_actions-2.301.1/Some/Folder/SomeProject.csproj'
+      }
+    },
+    {
+      // CSC error with MSBuild prefix
+      input:
+        '    20>C:\\actions-runner\\_work\\Some\\Folder\\SomeFile.cs(8,2): error CS1014: A get or set accessor expected [C:\\actions-runner\\_work\\Some\\Folder\\SomeProject.csproj]',
+      results: {
+        file: 'C:\\actions-runner\\_work\\Some\\Folder\\SomeFile.cs',
+        line: '8',
+        column: '2',
+        severity: 'error',
+        code: 'CS1014',
+        message: 'A get or set accessor expected',
+        fromPath: 'C:\\actions-runner\\_work\\Some\\Folder\\SomeProject.csproj'
+      }
+    }
+  ];
 
-    stringsToMatch.map((string, index) => {
-      const matchedResultsArray = string.match(regex);
-      for (const propName in expectedResults[index]) {
+  test.each(testCases)(
+    'regex matches and parses: $input',
+    ({input, results}: {input: string; results: Record<string, string>}) => {
+      const matchedResultsArray = input.match(regex);
+      expect(matchedResultsArray).not.toBeNull();
+
+      for (const propName in results) {
         const propertyIndex = regexResultsMap[propName];
-        const expectedPropValue = expectedResults[index][propName];
+        const expectedPropValue = results[propName];
         const matchedPropValue = matchedResultsArray![propertyIndex];
         expect(matchedPropValue).toEqual(expectedPropValue);
       }
-    });
-  }, 10000);
+    },
+    10000
+  );
 });


### PR DESCRIPTION
**Description:**

This extends the csc problem matcher to support more flexible error message syntax, with tests. All examples have been seen in actual GHA runner output (these are anonymized real-world cases).

There are three changes to the regex:

- At the beginning of the line, whitespace and msbuild-style project number prefixes (e.g., `10>`) are allowed. This is necessary for `dotnet msbuild` error parsing as well as `dotnet build` error parsing in some scenarios.
- Column numbers are now captured.
- Error codes no longer need to end in a number. This is necessary for `dotnet format` error parsing.

**Related issue:**

Replaces https://github.com/actions/setup-dotnet/pull/691. Also see https://github.com/actions/setup-dotnet/pull/583 which takes the alternative approach of adding an independent problem matcher for `dotnet format` (this PR includes `dotnet format` errors in the csc problem matcher).

**Check list:**
- [ ] Mark if documentation changes are required.
- [x] Mark if tests were added or updated to cover the changes.