### PR TITLE
docs(action): explicitly mark all optional inputs with required: false

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,18 +7,25 @@ branding:
 inputs:
   dotnet-version:
     description: 'Optional SDK version(s) to use. If not provided, will install global.json version when available. Examples: 2.2.104, 3.1, 3.1.x, 3.x, 6.0.2xx, latest'
+    required: false
   dotnet-quality:
     description: 'Optional quality of the build. The possible values are: daily, preview, ga.'
+    required: false
   dotnet-channel:
     description: 'Optional channel for the installation. The possible values are: STS, LTS, A.B (e.g. 8.0), A.B.Cxx (e.g. 8.0.1xx, available since 5.0). To be used with "dotnet-version: latest".'
+    required: false
   global-json-file:
     description: 'Optional global.json location, if your global.json isn''t located in the root of the repo.'
+    required: false
   source-url:
     description: 'Optional package source for which to set up authentication. Will consult any existing NuGet.config in the root of the repo and provide a temporary NuGet.config using the NUGET_AUTH_TOKEN environment variable as a ClearTextPassword'
+    required: false
   owner:
     description: 'Optional OWNER for using packages from GitHub Package Registry organizations/users other than the current repository''s owner. Only used if a GPR URL is also provided in source-url'
+    required: false
   config-file:
     description: 'Optional NuGet.config location, if your NuGet.config isn''t located in the root of the repo.'
+    required: false
   cache:
     description: 'Optional input to enable caching of the NuGet global-packages folder'
     required: false


### PR DESCRIPTION
## Summary
Explicitly adds `required: false` to all optional inputs in `action.yml` that were missing the declaration. No behavior is changed.

## Changes
- Added `required: false` to: `dotnet-version`, `dotnet-quality`, `dotnet-channel`, `global-json-file`, `source-url`, `owner`, `config-file`
- `cache`, `cache-dependency-path`, `workloads`, and `architecture` already had `required: false` and were not modified

## Motivation
GitHub Actions treats omitted `required` as `false` implicitly, but leaving it unset creates ambiguity for:
- Consumers reading `action.yml` to understand the action's contract
- Tooling (IDEs, linters, schema validators) that introspects action metadata
- Contributors assessing whether an input must be provided

## Impact
- **Users**: No behavioral change — all affected inputs were already optional in practice
- **Backward compatibility**: Fully preserved; this is a metadata-only change

## Testing
No code paths are affected. The `action.yml` schema change can be validated by running the existing test suite to confirm no regressions.

**Related issue:**
Change is only associated with documentation and no code changes are made.

**Check list:**
- [X] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.