### PR TITLE
Add rollForward note in README, improve proxy health check in e2e tests and bump version to v5.3.0

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -577,6 +577,11 @@ jobs:
         image: ubuntu/squid:latest
         ports:
           - 3128:3128
+        options: >-
+          --health-cmd "bash -c '</dev/tcp/localhost/3128'"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 10
     env:
       https_proxy: http://squid-proxy:3128
       http_proxy: http://squid-proxy:3128

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ steps:
   working-directory: csharp
 ```
 
-> **Note**: The action supports `latest*` variants of the [`rollForward`](https://learn.microsoft.com/en-us/dotnet/core/tools/global-json#rollforward) field in `global.json`. When set to `latestPatch`, `latestFeature`, `latestMinor`, or `latestMajor`, the action installs the appropriate SDK version.
+> **Note**: The action supports `latest*` variants of the [rollForward](https://learn.microsoft.com/en-us/dotnet/core/tools/global-json#rollforward) field in `global.json`. When set to `latestPatch`, `latestFeature`, `latestMinor`, or `latestMajor`, the action installs the appropriate SDK version.
 
 ## Caching NuGet Packages
 The action has a built-in functionality for caching and restoring dependencies. It uses [toolkit/cache](https://github.com/actions/toolkit/tree/main/packages/cache) under the hood for caching global packages data but requires less configuration settings. The `cache` input is optional, and caching is turned off by default.

--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ steps:
   working-directory: csharp
 ```
 
+> **Note**: The action supports `latest*` variants of the [`rollForward`](https://learn.microsoft.com/en-us/dotnet/core/tools/global-json#rollforward) field in `global.json`. When set to `latestPatch`, `latestFeature`, `latestMinor`, or `latestMajor`, the action installs the appropriate SDK version.
+
 ## Caching NuGet Packages
 The action has a built-in functionality for caching and restoring dependencies. It uses [toolkit/cache](https://github.com/actions/toolkit/tree/main/packages/cache) under the hood for caching global packages data but requires less configuration settings. The `cache` input is optional, and caching is turned off by default.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "setup-dotnet",
-  "version": "5.0.1",
+  "version": "5.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "setup-dotnet",
-      "version": "5.0.1",
+      "version": "5.3.0",
       "license": "MIT",
       "dependencies": {
         "@actions/cache": "^5.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-dotnet",
-  "version": "5.0.1",
+  "version": "5.3.0",
   "private": true,
   "description": "setup dotnet action",
   "main": "dist/setup/index.js",


### PR DESCRIPTION
**Description:**
- Adds a note in the `global-json-file` section of the README documenting support for `latest*` variants of the `rollForward` policy (`latestPatch`, `latestFeature`, `latestMinor`, and `latestMajor`) in `global.json`.
- Adds a health check for the squid proxy container in the e2e tests workflow.
- Bumps package version to `5.3.0`.

**Related issue:**
#448 

**Check list:**
- [X] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.