### PR TITLE
Improve global.json SDK version validation for rollForward

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -273,14 +273,14 @@ jobs:
         shell: bash
         run: |
           mkdir subdirectory
-          echo '{"sdk":{"version": "3.1.0","rollForward": "latestMajor"}}' > ./subdirectory/global.json
+          echo '{"sdk":{"version": "8.0.100","rollForward": "latestMajor"}}' > ./subdirectory/global.json
       - name: Setup dotnet
         uses: ./
         with:
           global-json-file: ./subdirectory/global.json
       - name: Verify dotnet
         shell: pwsh
-        run: __tests__/verify-dotnet.ps1 -Patterns "^(?!3)"
+        run: __tests__/verify-dotnet.ps1 -Patterns "^(?!8)"
 
   test-setup-global-json-rollforward-latestfeature:
     runs-on: ${{ matrix.operating-system }}

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ steps:
   working-directory: csharp
 ```
 
-> **Note**: The action supports `latest*` variants of the [rollForward](https://learn.microsoft.com/en-us/dotnet/core/tools/global-json#rollforward) field in `global.json`. When set to `latestPatch`, `latestFeature`, `latestMinor`, or `latestMajor`, the action installs the appropriate SDK version.
+> **Note**: The action supports `latest*` variants of the [rollForward](https://learn.microsoft.com/en-us/dotnet/core/tools/global-json#rollforward) field in `global.json`. When set to `latestPatch`, `latestFeature`, `latestMinor`, or `latestMajor`, the action installs the appropriate SDK version. For prerelease versions, the exact pinned version is always installed regardless of the `rollForward` setting.
 
 ## Caching NuGet Packages
 The action has a built-in functionality for caching and restoring dependencies. It uses [toolkit/cache](https://github.com/actions/toolkit/tree/main/packages/cache) under the hood for caching global packages data but requires less configuration settings. The `cache` input is optional, and caching is turned off by default.

--- a/src/setup-dotnet.ts
+++ b/src/setup-dotnet.ts
@@ -207,7 +207,16 @@ function getVersionFromGlobalJson(globalJsonPath: string): string {
   if (globalJson.sdk && globalJson.sdk.version) {
     version = globalJson.sdk.version;
     const rollForward = globalJson.sdk.rollForward;
-    if (rollForward) {
+    if (rollForward && !semver.prerelease(version)) {
+      const versionPattern = /^\d+\.\d+\.[1-9]\d{2,}$/;
+      if (!versionPattern.test(version)) {
+        throw new Error(
+          `Version '${version}' is not valid for the 'sdk.version' value in global.json. ` +
+            `When 'rollForward' is specified, a full SDK version is required. ` +
+            `See: https://learn.microsoft.com/en-us/dotnet/core/tools/global-json`
+        );
+      }
+
       const [major, minor, featurePatch] = version.split('.');
       const feature = featurePatch.substring(0, 1);
 


### PR DESCRIPTION
**Description:**
This PR validates the `sdk.version` format in `global.json` when `rollForward` is specified and skips rollForward optimization for prerelease SDK versions.

**Related issue:**
#739 
#740 

**Check list:**
- [X] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.