### PR TITLE
ci: make validation caches read-only

### DIFF
--- a/.github/workflows/basic-validation.yml
+++ b/.github/workflows/basic-validation.yml
@@ -14,6 +14,7 @@ on:
 jobs:
   call-basic-validation:
     name: Basic validation
+    cache-mode: read
     uses: actions/reusable-workflows/.github/workflows/basic-validation.yml@main
     with:
       node-version: '24'

--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -14,6 +14,7 @@ on:
 jobs:
   call-check-dist:
     name: Check dist/
+    cache-mode: read
     uses: actions/reusable-workflows/.github/workflows/check-dist.yml@main
     with:
       node-version: '24'


### PR DESCRIPTION
**Description:**
- Set job-level `cache-mode: read` on the Basic validation and Check dist reusable-workflow caller jobs.
- Propagate read-only cache access through each reusable workflow call so setup-node can restore existing npm caches without allowing the called workflow chain to write new entries.
- Leave the e2e cache jobs on the default read-and-write mode because they exercise setup-dotnet cache behavior and may need to populate or replenish their NuGet caches.

**Check list:**
- [x] Documentation changes are not required.
- [x] Tests are not required for this workflow configuration change; the changed YAML passed the repository formatting check.