### PR TITLE
Clarify dotnet-quality behavior for multiple SDK versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,20 @@ steps:
 
 The `dotnet-quality` input installs the latest build of the specified quality in the channel. Supported values: `daily`, `preview`, `ga`. For more details about quality options, see the [official .NET documentation](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-install-script#options).
 
+> **Important**: `dotnet-quality` applies to every version listed in `dotnet-version` for the same step. For example, setting `dotnet-quality: preview` for `10.0.x` and `11.0.x` resolves both versions as previews. Per-version quality is not supported. To install a released SDK alongside a preview SDK, use separate steps:
+
+```yaml
+steps:
+- uses: actions/setup-dotnet@v6
+  with:
+    dotnet-version: '10.0.x'
+
+- uses: actions/setup-dotnet@v6
+  with:
+    dotnet-version: '11.0.x'
+    dotnet-quality: 'preview'
+```
+
 > **Note**: When used with a specific SDK version, `dotnet-quality` supports only `A.B`, `A.B.x`, `A`, `A.x`, and `A.B.Cxx` formats where the major version is higher than 5. For all other formats, `dotnet-quality` will be ignored.
 
 ```yml


### PR DESCRIPTION
**Description:**
Document that dotnet-quality applies to every dotnet-version in the same step. Add the recommended two-step workflow for installing a released SDK alongside a preview SDK.

**Related issue:**
[778](https://github.com/actions/setup-dotnet/issues/778)

**Check list:**
- [x] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.